### PR TITLE
Updating an object on scope should not update on originating scope

### DIFF
--- a/app/scripts/services/Model.js
+++ b/app/scripts/services/Model.js
@@ -58,12 +58,18 @@ angular.module('confRegistrationWebApp')
     this.subscribe = function (scope, name, path) {
       scope.$watch(name, function (object) {
         if (angular.isDefined(object)) {
-          thisModel.update(path, object);
+          var cb = function () {
+            cache.put(path, angular.copy(object));
+            $rootScope.$broadcast(path, object, scope.$id);
+          };
+          thisModel.update(path, object, cb);
         }
       }, true);
 
-      scope.$on(path, function (event, object) {
-        scope[name] = angular.copy(object);
+      scope.$on(path, function (event, object, originScopeId) {
+        if (scope.$id !== originScopeId) {
+          scope[name] = angular.copy(object);
+        }
       });
 
       thisModel.get(path).then(function (object) {
@@ -71,14 +77,15 @@ angular.module('confRegistrationWebApp')
       });
     };
 
-    this.update = function (path, object) {
+    this.update = function (path, object, cb) {
+      var callback = cb || function () {
+        cache.put(path, angular.copy(object));
+        $rootScope.$broadcast(path, object);
+      };
       if (angular.equals(object, cache.get(path))) {
         // do nothing
       } else {
-        $http.put(path, object).then(function () {
-          cache.put(path, object);
-          $rootScope.$broadcast(path, object);
-        });
+        $http.put(path, object).then(callback);
       }
     };
   });


### PR DESCRIPTION
The reasoning for this is, a form might be depend on variables that get reset if scopes are torn down and rebuilt. By not updating the scope that causes the update, scopes don't get rebuilt and variables that affect forms are not reset.
