### PR TITLE
Various tweaks to displaying payments

### DIFF
--- a/app/scripts/controllers/adminData.js
+++ b/app/scripts/controllers/adminData.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('confRegistrationWebApp')
-  .controller('AdminDataCtrl', function ($scope, registrations, conference, $modal) {
+  .controller('AdminDataCtrl', function ($scope, registrations, conference, $http, $modal) {
     $scope.conference = conference;
 
     $scope.blocks = [];
@@ -65,22 +65,23 @@ angular.module('confRegistrationWebApp')
     $scope.registrations = registrations;
 
     $scope.viewPayments = function (registrationId) {
-      var registrationPayments = _.filter(registrations, function (item) { return item.id === registrationId; });
-      registrationPayments = registrationPayments[0].pastPayments;
-      console.log(registrationPayments);
+      $http.get('registrations/' + registrationId + '/payments').success(function(data) {
+        console.log(data);
 
-      var paymentModalOptions = {
-        templateUrl: 'views/paymentsModal.html',
-        controller: 'errorModal',
-        backdrop: 'static',
-        keyboard: false,
-        resolve: {
-          message: function () {
-            return registrationPayments;
+        var paymentModalOptions = {
+          templateUrl: 'views/paymentsModal.html',
+          controller: 'errorModal',
+          backdrop: 'static',
+          keyboard: false,
+          resolve: {
+            message: function () {
+              return data;
+            }
           }
-        }
-      };
-      $modal.open(paymentModalOptions).result.then(function () {
+        };
+        $modal.open(paymentModalOptions).result.then(function () {
+        });
+
       });
     };
   });

--- a/app/scripts/controllers/payment.js
+++ b/app/scripts/controllers/payment.js
@@ -81,6 +81,7 @@ angular.module('confRegistrationWebApp')
       $rootScope.currentPayment.creditCardExpirationYear = $scope.creditCardExpirationYear;
       $rootScope.currentPayment.creditCardNumber = $scope.creditCardNumber;
       $rootScope.currentPayment.creditCardCVVNumber = $scope.creditCardCVVNumber;
+      $rootScope.currentPayment.paymentType = 'CREDIT_CARD';
 
       if (registration.completed) {
         var currentPayment = $rootScope.currentPayment;

--- a/app/views/adminData.html
+++ b/app/views/adminData.html
@@ -43,7 +43,7 @@
       <td data-ng-repeat="block in blocks | filter:{ visible: true }">
         <show-answer answers="registration.answers" block="block"></show-answer>
       </td>
-      <td><a href="" data-ng-click="viewPayments('{{registration.id}}')">View</a></td>
+      <td><a href="" data-ng-click="viewPayments(registration.id)">View</a></td>
     </tr>
     </tbody>
   </table>

--- a/app/views/paymentsModal.html
+++ b/app/views/paymentsModal.html
@@ -9,12 +9,14 @@
         <tr>
           <th>Date</th>
           <th>Amount</th>
-          <th>Transaction</th>
+          <th>Type</th>
+          <th>Reference #</th>
         </tr>
         </thead>
         <tr data-ng-repeat="payment in message">
           <td>{{payment.transactionDatetime | date:'MMM d, y h:mm a'}}</td>
           <td>${{payment.amount}}</td>
+          <td>{{payment.paymentType}}</td>
           <td>{{payment.authnetTransactionId}}</td>
         </tr>
       </table>


### PR DESCRIPTION
- Payments are now fetched by a direct call to the Payments endpoint (via $http) instead of using a cache
  - I'm not sure if this is ideal or not, feedback welcome
- When creating a payment, paymentType 'CREDIT_CARD' is required for processing a CC payment
- Adding paymentType to paymentsModal
- Changing label "Transaction" -> "Reference #" in paymentsModal.
  - This could probably use a tooltip for more information
