### PR TITLE
ConferenceCache will include initial page and blocks

### DIFF
--- a/app/scripts/services/ConfCache.js
+++ b/app/scripts/services/ConfCache.js
@@ -46,30 +46,34 @@ angular.module('confRegistrationWebApp')
         registrationStartTime: new Date(),
         registrationEndTime: registrationEndTime,
         contactPersonName: '',
-        registrationPages: [{
-          id: newPageId,
-          conferenceId: newConferenceId,
-          title: 'Sign Up',
-          position: 0,
-          blocks: [{
-            id: uuid(),
-            pageId: newPageId,
-            type: 'nameQuestion',
-            profileType: 'NAME',
-            title: 'Name',
+        registrationPages: [
+          {
+            id: newPageId,
+            conferenceId: newConferenceId,
+            title: 'Sign Up',
             position: 0,
-            required: true
-          },{
-            id: uuid(),
-            pageId: newPageId,
-            type: 'emailQuestion',
-            title: 'Email Address',
-            profileType: 'EMAIL',
-            position: 1,
-            required: true
+            blocks: [
+              {
+                id: uuid(),
+                pageId: newPageId,
+                type: 'nameQuestion',
+                profileType: 'NAME',
+                title: 'Name',
+                position: 0,
+                required: true
+              },
+              {
+                id: uuid(),
+                pageId: newPageId,
+                type: 'emailQuestion',
+                title: 'Email Address',
+                profileType: 'EMAIL',
+                position: 1,
+                required: true
+              }
+            ]
           }
-          ]
-        }]
+        ]
       };
       return $http.post(path(), data).then(function (response) {
         if (response.status === 201) {

--- a/app/scripts/services/apiUrl.js
+++ b/app/scripts/services/apiUrl.js
@@ -1,4 +1,4 @@
 'use strict';
 
 angular.module('confRegistrationWebApp')
-  .constant('apiUrl', 'http://localhost:8080/crs-http-json-api/rest/');
+  .constant('apiUrl', 'http://CRS-elb-2069964056.us-east-1.elb.amazonaws.com:8080/crs-http-json-api/rest/');


### PR DESCRIPTION
When creating a new conference, we want to pre-populate it with an initial page and name & email profile questions as those will be required on all sign-ups.
