### PR TITLE
Move registration export and manual admin registration links from adminN...

### DIFF
--- a/app/views/adminData.html
+++ b/app/views/adminData.html
@@ -16,6 +16,9 @@
 </style>
 
 <div admin-nav></div>
+<a href="" data-ng-click="exportRegistrations(conference.id)">Export Registrations</a> |
+<a href="" data-ng-show="hasCost(conference)" data-ng-click="exportPayments(conference.id)">Export Payments |</a>
+<a href="" data-ng-click="registerUser(conference.id)">Register Someone</a>
 <h2>{{conference.name}}</h2>
 
 <div data-ng-show="registrations.length > 0">

--- a/app/views/adminNav.html
+++ b/app/views/adminNav.html
@@ -4,8 +4,5 @@
   <a href="#/adminDetails/{{conference.id}}">Edit Conference Details</a> |
   <a href="#/permissions/{{conference.id}}">Conference Permissions</a> |
   <a href="#/register/{{conference.id}}" target="_blank">Preview Registration Form</a> |
-  <a href="" data-ng-click="exportRegistrations(conference.id)">Export Registrations</a> |
-  <a href="" data-ng-show="hasCost(conference)" data-ng-click="exportPayments(conference.id)">Export Payments</a> |
-  <a href="" data-ng-click="registerUser(conference.id)">Register Someone</a> |
   <a href="" data-ng-click="deleteConference(conference.id)">Delete Conference</a>
 </p>


### PR DESCRIPTION
...av.html to adminData.html.

This places them in a more contextually relevant location
And eliminates an issue where conference was not defined in scope yet when adminNav.html was attempting to reference it.
