### PR TITLE
Facebook single logout

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -192,7 +192,7 @@ angular.module('confRegistrationWebApp', ['ngRoute', 'ngCookies', 'ui.bootstrap'
                 delete $cookies.crsPreviousToken;
                 delete $cookies.crsToken;
                 // make sure we come back to home page, not logout page
-                var serviceUrl = $location.absUrl().replace("logout","");
+                var serviceUrl = $location.absUrl().replace('logout','');
                 $window.location.href = 'https://signin.cru.org/cas/logout?service=' + serviceUrl;
                 /* if FACEBOOK log out, issue an async GET to retrieve the log out URL from the API
                  * the cookies cannot be deleted first b/c the auth token is needed to access the session & identity


### PR DESCRIPTION
When clicking logout as a facebook user, redirect to the API's facebook logout URL.  The ERT API will expire the ERT session and issue a call to facebook logging the user out
- this facilitates shared computers where users authenticate with facebook, but then need to logout so that someone else can login
