### PR TITLE
Initialize currentPayment.creditCard as object, not array

### DIFF
--- a/app/scripts/controllers/reviewRegistration.js
+++ b/app/scripts/controllers/reviewRegistration.js
@@ -24,7 +24,7 @@ angular.module('confRegistrationWebApp')
     if (angular.isUndefined($rootScope.currentPayment)) {
       $rootScope.currentPayment = {
         amount: 0,
-        creditCard: []
+        creditCard: {}
       };
     }
     $rootScope.currentPayment.amount = registration.calculatedTotalDue;


### PR DESCRIPTION
In stage, this caused credit card data not to be assembled under creditCard.currentPayment and the endpoint returned a 400 bad request.  Initializing the object as an object instead of an array solves the problem - especially because there is just one payment, at this point.
