### PR TITLE
Remove auth routes from history

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -162,10 +162,10 @@ angular.module('confRegistrationWebApp', ['ngRoute', 'ngCookies', 'ui.bootstrap'
               ProfileCache.getCache(function (data) {
                 $cookies.crsAuthProviderType = data.authProviderType;
                 if(angular.isDefined($cookies.regType)) {
-                  $location.path($cookies.intendedRoute || '/').search('regType', $cookies.regType);
+                  $location.path($cookies.intendedRoute || '/').search('regType', $cookies.regType).replace();
                   delete $cookies.regType;
                 } else {
-                  $location.path($cookies.intendedRoute || '/');
+                  $location.path($cookies.intendedRoute || '/').replace();
                 }
               });
             }


### PR DESCRIPTION
Use `replace()` to remove the auth routes from browser history. This allows the user to go back to the page they were at before the auth request. Currently if the user hits the back button after signing in, they go back to the auth route which then redirects them to the page they were already at. They aren't allowed to go back any further in the history.

A use case would be that a user searches for a conference and realizes it is the wrong conference and wants to go back and search for a different one.

I believe this only works if there wasn't a sign in involved (ie. conference didn't require user to be logged in). I realized that this is less useful if you can't get back past the Relay/FB sign in. It is hard to test because I get redirected away from localhost to stage so much. Let me know if you think it is useful.