### PR TITLE
Fix error on saving editBlockOptionAdvanced modal

### DIFF
--- a/app/scripts/directives/block.js
+++ b/app/scripts/directives/block.js
@@ -106,7 +106,7 @@ angular.module('confRegistrationWebApp')
               };
 
               $scope.save = function (choice) {
-                if(choice.amount == null){
+                if(!choice.amount){
                   choice.amount = 0;
                 }else if(_.isString(choice.amount)){
                   choice.amount = choice.amount.replace(',','');

--- a/app/scripts/directives/block.js
+++ b/app/scripts/directives/block.js
@@ -106,7 +106,11 @@ angular.module('confRegistrationWebApp')
               };
 
               $scope.save = function (choice) {
-                choice.amount = choice.amount.replace(',','');
+                if(choice.amount == null){
+                  choice.amount = 0;
+                }else if(_.isString(choice.amount)){
+                  choice.amount = choice.amount.replace(',','');
+                }
                 if(_.isNaN(Number(choice.amount))){
                   alert('Error: please enter a valid additional cost.');
                 }else{

--- a/app/scripts/directives/block.js
+++ b/app/scripts/directives/block.js
@@ -106,7 +106,7 @@ angular.module('confRegistrationWebApp')
               };
 
               $scope.save = function (choice) {
-                if(!choice.amount){
+                if(_.isUndefined(choice.amount)){
                   choice.amount = 0;
                 }else if(_.isString(choice.amount)){
                   choice.amount = choice.amount.replace(',','');


### PR DESCRIPTION
I noticed this while going through the modals and cleaning up styling for the responsive branch. If choice.amount is undefined or 0 (not '0'), this function throws an error about not being able to call replace on undefined and doesn't allow the user to save and close the modal. @adammeyer can you review?