### PR TITLE
Sort registrantTypes array

### DIFF
--- a/app/scripts/directives/block.js
+++ b/app/scripts/directives/block.js
@@ -140,12 +140,9 @@ angular.module('confRegistrationWebApp')
           });
           $scope.$watch('visibleRegTypes', function (object) {
             if (angular.isDefined(object)) {
-              $scope.block.registrantTypes = [];
-              angular.forEach(object, function(v, k) {
-                if(!v){
-                  $scope.block.registrantTypes.push(k);
-                }
-              });
+              $scope.block.registrantTypes = _.keys(_.pick(object, function(v){
+                return !v;
+              })).sort();
             }
           }, true);
 


### PR DESCRIPTION
This fix is for the question editor:

This change along with one from the API (EVENT-242) will keep the registrant types in this array in the same order.  When they are returned/saved in a random order, it causes the angular $watch comparison on the object to think they are different and immediately save the conference on page load.
