### PR TITLE
Fix unselected payment type bug

### DIFF
--- a/app/scripts/controllers/reviewRegistration.js
+++ b/app/scripts/controllers/reviewRegistration.js
@@ -53,11 +53,6 @@ angular.module('confRegistrationWebApp')
       };
     }
 
-    $scope.isPaymentMethodValid = function(){
-      //If nothing is due, there are no ways to pay, or if the payment type is selected, then valid
-      return $scope.currentRegistration.remainingBalance === 0 || !$scope.acceptedPaymentMethods() || !_.isUndefined($scope.currentPayment.paymentType);
-    }
-
     angular.forEach(_.flatten(conference.registrationPages, 'blocks'), function (block) {
       if (block.type.indexOf('Content') === -1) {
         $scope.blocks.push(block);
@@ -77,6 +72,16 @@ angular.module('confRegistrationWebApp')
     };
 
     $scope.confirmRegistration = function () {
+      var isPaymentMethodValid = function(){
+        //If nothing is due, there are no ways to pay, or if the payment type is selected, then valid
+        return $scope.currentRegistration.remainingBalance === 0 || !$scope.acceptedPaymentMethods() || !_.isUndefined($scope.currentPayment.paymentType);
+      };
+
+      if(!isPaymentMethodValid()){
+        modalMessage.error('Please select a payment type to finish your registration.', false, 'Payment type not chosen');
+        return;
+      }
+
       $scope.submittingRegistration = true;
 
       /*if the totalPaid (previously) AND the amount of this payment are less than the minimum required deposit, then

--- a/app/views/reviewRegistration.html
+++ b/app/views/reviewRegistration.html
@@ -149,7 +149,7 @@
     </section>
     <section class="text-center spacing-above-md" ng-if="!currentRegistration.completed || (acceptedPaymentMethods() && currentRegistration.remainingBalance > 0)">
       <p ng-if="!allRegistrantsValid()" style="color:red;">Please fill in all required fields in red before submitting.</p>
-      <input type="button" class="btn btn-lg btn-success btn-important confirm-registration" ng-click="confirmRegistration()" value="Confirm" ng-disabled="registerMode === 'preview' || !allRegistrantsValid() || submittingRegistration || !isPaymentMethodValid()">
+      <input type="button" class="btn btn-lg btn-success btn-important confirm-registration" ng-click="confirmRegistration()" value="Confirm" ng-disabled="registerMode === 'preview' || !allRegistrantsValid() || submittingRegistration">
       <span ng-show="registerMode === 'preview'">&laquo; Disabled in preview mode</span>
     </section>
     <section class="text-center spacing-above-md" ng-if="currentRegistration.completed">


### PR DESCRIPTION
@adammeyer @ryancarlson I found a bug (both in the responsive branch and in PRODUCTION) where clicking confirm without selecting a payment type results in a logout, reload, and redirection to the start of the registration with all registrants forgotten.

These are the causes I see:

API issues:
- `paymentAllowed(payment)` returns `false` cuz the payment type is null (https://github.com/CruGlobal/conf-registration-api/blob/master/src/main/java/org/cru/crs/api/process/PaymentProcessor.java#L106)
- Then `verifyUserHasUpdateConferenceRights(conferenceForThisPayment, loggedInUser)` eventually returns a 401 because the user registering does not have those rights (https://github.com/CruGlobal/conf-registration-api/blob/master/src/main/java/org/cru/crs/api/process/PaymentProcessor.java#L111)

Web client issues:
- Fires a POST request to https://api.stage.eventregistrationtool.com/eventhub-api/rest/payments/ which returns a 401 Unauthorized (see API issues)
- Then (in the responsive branch only) I get a modal right before the logout with the error message "Your payment was declined, please verify your details or use a different payment method."
- Since the app received a 401, https://github.com/CruGlobal/conf-registration-web/blob/master/app/scripts/services/unauthorizedInterceptor.js is executed which essentially performs a logout by deleting the `crsToken` cookies and then reloads the page.
- After the reload, (and a login) we are redirected to the first page of the registration because there are currently no registrants associated with the new `crsToken`.

This PR disables the final Confirm button when there is a cost, there are available ways to pay, and the payment type is unselected. It does nothing about the 401 issue.
