### PR TITLE
Replace accordions with panels containing full width list-groups

### DIFF
--- a/app/views/landing.html
+++ b/app/views/landing.html
@@ -29,7 +29,7 @@
     <div class="col-md-4">
       <h4>Filters</h4>
       <div class="panel panel-default">
-        <div class="panel-heading">Location</div>
+        <div class="panel-heading panel-title">Location</div>
         <div class="list-group">
           <a href=""
              class="list-group-item"
@@ -44,7 +44,7 @@
         </div>
       </div>
       <div class="panel panel-default">
-        <div class="panel-heading">Date</div>
+        <div class="panel-heading panel-title">Date</div>
         <div class="list-group">
           <a href=""
              class="list-group-item"


### PR DESCRIPTION
@adammeyer I created this to see what they look like. I think I like the panels better but you can see what you think. They aren't that different. If you keep the accordion, the spacing below the list-group needs to be removed and about 20px of space between each panel needs to be added.

My thoughts on the accordion: I don't think the accordion would be useful on desktop. Even if there are lots of locations it should be pretty easy to scroll to the dates. On mobile, they might take up a lot of space but they are open by default so I doubt people will close the panels often or even know that feature exists. If they were closed by default on mobile it might make sense.
