### PR TITLE
On the list of registrations conference admin page, Unlock "Started,"Completed" and "Email" display columns to allow admin to remove from display screen (leaving the "First Name," "Last Name," "Registrant Type" and "Paid" locked.

### DIFF
--- a/app/scripts/controllers/eventRegistrations.js
+++ b/app/scripts/controllers/eventRegistrations.js
@@ -72,6 +72,7 @@ angular.module('confRegistrationWebApp')
         }
       });
     });
+
     //turn on visible blocks
     var visibleBlocks = localStorage.getItem('visibleBlocks:' + conference.id);
     if(!_.isNull(visibleBlocks)){
@@ -85,12 +86,32 @@ angular.module('confRegistrationWebApp')
       });
     }
 
-    // toggle (show/hide) column(s)
-    $scope.toggleColumn = function (block) {
+    //toggle (show/hide) columns
+    $scope.toggleColumn = function(block) {
       $scope.blocks[block].visible = !$scope.blocks[block].visible;
       visibleBlocks =  _.pluck(_.where($scope.blocks, { 'visible': true }), 'id');
       localStorage.setItem('visibleBlocks:' + conference.id, JSON.stringify(visibleBlocks));
       $scope.queryParameters.block = visibleBlocks;
+    };
+
+    //turn on visible built in columns
+    var builtInColumnsVisibleInStorage = localStorage.getItem('builtInColumnsVisibleStorage');
+    if(typeof builtInColumnsVisibleInStorage === 'undefined' || builtInColumnsVisibleInStorage === null){
+      //Initally display (true) or not display (false) built in columns
+      $scope.builtInColumnsVisible = {
+        Email: true,
+        Started: true,
+        Completed: true
+      };
+    }
+    else {
+        $scope.builtInColumnsVisible = JSON.parse(builtInColumnsVisibleInStorage);
+    }
+
+    //toggle (show/hide) built in columns
+    $scope.toggleBuiltInColumn = function(columnName) {
+      $scope.builtInColumnsVisible[columnName] = !$scope.builtInColumnsVisible[columnName];
+      localStorage.setItem('builtInColumnsVisibleStorage', JSON.stringify($scope.builtInColumnsVisible));
     };
 
     var throttleFilter = _.debounce(function(){

--- a/app/views/eventRegistrations.html
+++ b/app/views/eventRegistrations.html
@@ -1,18 +1,18 @@
 <div class="container full">
   <div class="row">
     <div class="col-sm-7">
-      <h2 class="page-title" translate>Registrations</h2>
+      <h2 class="page-title">Registrations</h2>
     </div>
     <div class="col-sm-5 text-right">
-      <button class="btn btn-success btn-sm" type="button" ng-click="registerUser()"><i class="fa fa-plus"></i> <translate>Add Registration</translate></button>
-      <a class="btn btn-primary btn-sm" href="" ng-click="export()"><i class="fa fa-cloud-download"></i> <translate>Export</translate></a>
+      <button class="btn btn-success btn-sm" type="button" ng-click="registerUser()"><i class="fa fa-plus"></i> Add Registration</button>
+      <a class="btn btn-primary btn-sm" href="" ng-click="export()"><i class="fa fa-cloud-download"></i> Export</a>
     </div>
   </div>
   <div class="row well well-full spacing-above-xs spacing-below-sm">
     <div class="row">
-      <div class="col-md-4 col-sm-8 stacked-spacing-col-md">
+      <div class="col-md-3 col-sm-8">
         <div class="form-group has-feedback has-clear">
-          <label><translate>Search</translate> <small>(<translate>visible columns only</translate>)</small>:</label>
+          <label>Search<small> (visible columns only)</small>:</label>
           <input type="text" class="form-control" ng-model="strFilter">
           <span class="form-control-feedback form-control-clear" ng-click="resetStrFilter()" title="Clear search" ng-if="strFilter">
             <i class="fa fa-times"></i>
@@ -20,39 +20,59 @@
         </div>
       </div>
       <div class="col-md-2 col-sm-4 stacked-spacing-col-sm">
-        <label><translate>Payment status</translate>:</label>
+        <label>Payment status:</label>
         <select ng-model="queryParameters.filterPayment" class="form-control">
-          <option value="" translate>-Any-</option>
-          <option value="full" translate>Full/Overpaid</option>
-          <option value="partial" translate>Partial</option>
-          <option value="full-partial" translate>Full/Partial</option>
-          <option value="none" translate>Not Paid</option>
-          <option value="over" translate>Overpaid</option>
+          <option value="">-Any-</option>
+          <option value="full">Full/Overpaid</option>
+          <option value="partial">Partial</option>
+          <option value="full-partial">Full/Partial</option>
+          <option value="none">Not Paid</option>
+          <option value="over">Overpaid</option>
         </select>
       </div>
-      <div class="col-md-2 col-sm-7 stacked-spacing-col-sm">
-        <label translate>Registrant type:</label>
+      <div class="col-md-2 col-sm-6 stacked-spacing-col-sm">
+        <label>Registrant type:</label>
         <select ng-model="queryParameters.filterRegType" ng-options="t.id as t.name for t in visibleFilterRegistrantTypes" class="form-control"></select>
       </div>
-      <div class="col-md-4 col-sm-5 text-right">
+      <div class="col-md-5 col-sm-6 text-right">
         <br>
         <div class="btn-group" role="group" dropdown auto-close="outsideClick">
           <button class="btn btn-default" ng-model="showMoreFilters" btn-checkbox>
-            <translate>Filters</translate>
+            Filters
             <i class="fa fa-chevron-down" ng-show="!showMoreFilters"></i>
             <i class="fa fa-chevron-up" ng-show="showMoreFilters"></i>
           </button>
-          <button class="btn btn-primary" ng-click="refreshRegistrations()"><i class="fa fa-refresh"></i> <translate>Refresh</translate></button>
+          <button class="btn btn-primary" ng-click="refreshRegistrations()">
+            <i class="fa fa-refresh"></i>
+            Refresh
+          </button>
           <button type="button" class="btn btn-primary dropdown-toggle" dropdown-toggle>
-            <translate>Columns</translate>
+            <span class="hidden-xs">Display</span> Columns
             <i class="fa fa-caret-down"></i>
           </button>
           <ul class="dropdown-menu dropdown-menu-right reg-views-dropdown">
+            <li>
+              <a href="" ng-click="toggleBuiltInColumn('Email')">
+                <i ng-class="builtInColumnsVisible.Email ? 'fa fa-check-square' : 'fa fa-square-o'"></i>
+                Email
+              </a>
+            </li>
             <li ng-repeat="block in blocks" ng-if="block.profileType !== 'NAME' && block.profileType !== 'EMAIL'">
               <a href="" ng-click="toggleColumn($index)">
-                <i class="fa fa-check-square" ng-show="block.visible"></i>
-                <i class="fa fa-square-o" ng-show="!block.visible"></i>
+                <i ng-class="block.visible ? 'fa fa-check-square' : 'fa fa-square-o'"></i>
                 {{block.exportFieldTitle || block.title}}
+              </a>
+            </li>
+            <li>
+              <a href="" ng-click="toggleBuiltInColumn('Started')">
+                <i ng-class="builtInColumnsVisible.Started ? 'fa fa-check-square' : 'fa fa-square-o'"></i>
+                Started
+              </a>
+            </li>
+            <li>
+              <a href="" ng-click="toggleBuiltInColumn('Completed')">
+                <i ng-class="builtInColumnsVisible.Completed ? 'fa fa-check-square' : 'fa fa-square-o'"></i>
+                Completed
               </a>
             </li>
           </ul>
@@ -61,27 +81,27 @@
     </div>
     <div class="row spacing-above-sm well-border-above" collapse="!showMoreFilters">
       <div class="col-sm-4 stacked-spacing-col-sm">
-        <label translate>Incomplete registrations</label>
+        <label>Incomplete registrations</label>
         <div class="btn-group btn-group-justified">
-          <label class="btn btn-default" ng-model="queryParameters.includeIncomplete" btn-radio="'yes'" translate>Show</label>
-          <label class="btn btn-default" ng-model="queryParameters.includeIncomplete" btn-radio="'no'" translate>Hide</label>
-          <label class="btn btn-default" ng-model="queryParameters.includeIncomplete" btn-radio="'only'" translate>Only</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeIncomplete" btn-radio="'yes'">Show</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeIncomplete" btn-radio="'no'">Hide</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeIncomplete" btn-radio="'only'">Only</label>
         </div>
       </div>
       <div class="col-sm-4 stacked-spacing-col-sm">
-        <label translate>Checked-in registrations</label>
+        <label>Checked-in registrations</label>
         <div class="btn-group btn-group-justified">
-          <label class="btn btn-default" ng-model="queryParameters.includeCheckedin" btn-radio="'yes'" translate>Show</label>
-          <label class="btn btn-default" ng-model="queryParameters.includeCheckedin" btn-radio="'no'" translate>Hide</label>
-          <label class="btn btn-default" ng-model="queryParameters.includeCheckedin" btn-radio="'only'" translate>Only</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeCheckedin" btn-radio="'yes'">Show</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeCheckedin" btn-radio="'no'">Hide</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeCheckedin" btn-radio="'only'">Only</label>
         </div>
       </div>
       <div class="col-sm-4 stacked-spacing-col-sm">
-        <label translate>Withdrawn registrations</label>
+        <label>Withdrawn registrations</label>
         <div class="btn-group btn-group-justified">
-          <label class="btn btn-default" ng-model="queryParameters.includeWithdrawn" btn-radio="'yes'" translate>Show</label>
-          <label class="btn btn-default" ng-model="queryParameters.includeWithdrawn" btn-radio="'no'" translate>Hide</label>
-          <label class="btn btn-default" ng-model="queryParameters.includeWithdrawn" btn-radio="'only'" translate>Only</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeWithdrawn" btn-radio="'yes'">Show</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeWithdrawn" btn-radio="'no'">Hide</label>
+          <label class="btn btn-default" ng-model="queryParameters.includeWithdrawn" btn-radio="'only'">Only</label>
         </div>
       </div>
     </div>
@@ -93,7 +113,7 @@
         <label class="btn btn-default" ng-model="queryParameters.limit" btn-radio="20">20</label>
         <label class="btn btn-default" ng-model="queryParameters.limit" btn-radio="50">50</label>
         <label class="btn btn-default" ng-model="queryParameters.limit" btn-radio="100">100</label>
-        <label class="btn btn-default" disabled="disabled" translate>per page</label>
+        <label class="btn btn-default" disabled="disabled">per page</label>
       </div>
     </div>
     <div class="col-sm-8 text-right">
@@ -102,14 +122,14 @@
   </div>
   <div class="row spacing-below-xs" ng-if="registrants.length > 0">
     <div class="col-sm-12">
-      <translate>Showing</translate> {{registrants.length || 0}}<ng-pluralize count="meta.totalRegistrantsFilter" when="{'1': ' of {} registrant', 'other': ' of {} registrants'}"></ng-pluralize>
+      Showing {{registrants.length || 0}}<ng-pluralize count="meta.totalRegistrantsFilter" when="{'1': ' of {} registrant', 'other': ' of {} registrants'}"></ng-pluralize>
       <ng-pluralize count="meta.totalPages" when="{'0': '', '1': '', 'other': ' on {} pages'}"></ng-pluralize>
     </div>
   </div>
 
   <div class="row" ng-if="registrants.length === 0">
     <div class="col-xs-12">
-      <p translate>No registrations have been found to match your filter.</p>
+      <p>No registrations have been found to match your filter.</p>
     </div>
   </div>
   <div class="row">
@@ -118,14 +138,14 @@
         <thead>
         <tr>
           <th>
-            <a href="" ng-click="setOrder('first_name')" translate>First Name</a>
+            <a href="" ng-click="setOrder('first_name')">First Name</a>
             <i ng-if="queryParameters.orderBy === 'first_name'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i>
           </th>
           <th>
-            <a href="" ng-click="setOrder('last_name')" translate>Last Name</a>
+            <a href="" ng-click="setOrder('last_name')">Last Name</a>
             <i ng-if="queryParameters.orderBy === 'last_name'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i></th>
-          <th>
-            <a href="" ng-click="setOrder('email')" translate>Email</a>
+          <th ng-if="builtInColumnsVisible.Email">
+            <a href="" ng-click="setOrder('email')">Email</a>
             <i ng-if="queryParameters.orderBy === 'email'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i>
           </th>
           <th ng-repeat="block in blocks | filter:{ visible: true }">
@@ -133,20 +153,20 @@
             <i ng-if="queryParameters.orderBy === block.id" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i>
           </th>
           <th ng-show="conference.registrantTypes.length > 1" class="text-center" width="150">
-            <a href="" ng-click="setOrder('registrant_type_id')" translate>Type</a>
+            <a href="" ng-click="setOrder('registrant_type_id')">Type</a>
             <i ng-if="queryParameters.orderBy === 'registrant_type_id'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i>
           </th>
-          <th class="text-center" width="160">
-            <a href="" ng-click="setOrder('created_timestamp')" translate>Started</a>
+          <th class="text-center" width="160" ng-if="builtInColumnsVisible.Started">
+            <a href="" ng-click="setOrder('created_timestamp')">Started</a>
             <i ng-if="queryParameters.orderBy === 'created_timestamp'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i>
           </th>
-          <th class="text-center" width="160">
-            <a href="" ng-click="setOrder('completed_timestamp')" translate>Completed</a>
+          <th class="text-center" width="160" ng-if="builtInColumnsVisible.Completed">
+            <a href="" ng-click="setOrder('completed_timestamp')">Completed</a>
             <i ng-if="queryParameters.orderBy === 'completed_timestamp'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i>
           </th>
 
           <th class="text-center" width="70">
-            <translate>Paid</translate>
+            Paid
             <i class="fa fa-question-circle"
                button popover-template="paidPopoverTemplateUrl"
                popover-trigger="mouseenter"
@@ -155,24 +175,24 @@
           </th>
 
           <th class="text-center" width="94">
-            <a href="" ng-click="setOrder('checked_in_timestamp')" translate>Checked-in</a>
+            <a href="" ng-click="setOrder('checked_in_timestamp')">Checked-in</a>
             <i ng-if="queryParameters.orderBy === 'checked_in_timestamp'" class="fa" ng-class="{'fa-caret-down': reversesort, 'fa-caret-up': !reversesort}"></i></th>
-          <th class="text-center" width="146" translate>Options</th>
+          <th class="text-center" width="146">Options</th>
         </tr>
         </thead>
         <tbody>
         <tr ng-repeat-start="r in registrants | orderBy:answerSort:reversesort" ng-class="{'active': $even}" class="noselect">
           <td ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}">{{r.firstName}}</td>
           <td ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}">{{r.lastName}}</td>
-          <td ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}">{{r.email}}</td>
+          <td ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}" ng-if="builtInColumnsVisible.Email">{{r.email}}</td>
           <td ng-repeat="block in blocks | filter:{ visible: true }" ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}">
             <show-answer block="block" registrant="r" ng-if="blockIsVisible(block, r)"></show-answer>
           </td>
           <td class="text-center" ng-show="conference.registrantTypes.length > 1" ng-class="{'strike-through':r.withdrawn}" ng-bind="getRegistrantType(r.registrantTypeId).name"></td>
-          <td class="text-center" ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}">
+          <td class="text-center" ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}" ng-if="builtInColumnsVisible.Started">
             {{r.createdTimestamp | date: 'short'}}
           </td>
-          <td class="text-center" ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}">
+          <td class="text-center" ng-click="expandRegistration(r.id)" ng-class="{'strike-through':r.withdrawn}" ng-if="builtInColumnsVisible.Completed">
             {{getRegistration(r.registrationId).completed ? (getRegistration(r.registrationId).completedTimestamp | date: 'short') : '-'}}
           </td>
           <td class="text-center">
@@ -222,19 +242,19 @@
                 <div class="col-xs-9"><show-answer block="block" registrant="r"></show-answer></div>
               </div>
               <div class="row">
-                <div class="col-xs-3 details-heading" translate>Started on</div>
+                <div class="col-xs-3 details-heading">Started on</div>
                 <div class="col-xs-9">{{r.createdTimestamp | evtDateFormat: conference.eventTimezone}}</div>
               </div>
               <div class="row" ng-show="getRegistration(r.registrationId).completed">
-                <div class="col-xs-3 details-heading" translate>Completed on</div>
+                <div class="col-xs-3 details-heading">Completed on</div>
                 <div class="col-xs-9">{{getRegistration(r.registrationId).completedTimestamp | evtDateFormat: conference.eventTimezone}}</div>
               </div>
               <div class="row" ng-show="r.withdrawn">
-                <div class="col-xs-3 details-heading" translate>Withdrawn on</div>
+                <div class="col-xs-3 details-heading">Withdrawn on</div>
                 <div class="col-xs-9">{{r.withdrawnTimestamp | evtDateFormat: conference.eventTimezone}}</div>
               </div>
               <div class="row" ng-show="r.checkedInTimestamp">
-                <div class="col-xs-3 details-heading" translate>Checked in at</div>
+                <div class="col-xs-3 details-heading">Checked in at</div>
                 <div class="col-xs-9">{{r.checkedInTimestamp | evtDateFormat: conference.eventTimezone}}</div>
               </div>
             </div>
@@ -250,7 +270,7 @@
         <label class="btn btn-default" ng-model="queryParameters.limit" btn-radio="20">20</label>
         <label class="btn btn-default" ng-model="queryParameters.limit" btn-radio="50">50</label>
         <label class="btn btn-default" ng-model="queryParameters.limit" btn-radio="100">100</label>
-        <label class="btn btn-default" disabled="disabled" translate>per page</label>
+        <label class="btn btn-default" disabled="disabled">per page</label>
       </div>
     </div>
     <div class="col-sm-8 text-right">


### PR DESCRIPTION
On the list of registrations conference admin page, Unlock
"Started,"Completed" and "Email" display columns to allow admin to remove
from display screen (leaving the "First Name," "Last Name," "Registrant
Type" and "Paid" locked.