### PR TITLE
EVENT-379: Enable min/max validation on numberQuestion. Fix numberQuestion rules

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -95,6 +95,7 @@
   <script src="scripts/directives/selectOnClick.js"></script>
   <script src="scripts/directives/showAnswer.js"></script>
   <script src="scripts/directives/showErrors.js"></script>
+  <script src="scripts/directives/stringToNumber.js"></script>
 
   <!--Filters-->
   <script src="scripts/filters/evtDateFormat.js"></script>

--- a/app/scripts/directives/blockEditor.js
+++ b/app/scripts/directives/blockEditor.js
@@ -218,6 +218,8 @@ angular.module('confRegistrationWebApp')
               return ['M', 'F'];
             case 'yearInSchoolQuestion':
               return ['Freshman', 'Sophomore', 'Junior', 'Senior', 'Graduate Student'];
+            case 'numberQuestion':
+              return block.content.range;
             default:
               return [];
           }

--- a/app/scripts/directives/showErrors.js
+++ b/app/scripts/directives/showErrors.js
@@ -15,13 +15,13 @@ angular.module('confRegistrationWebApp')
         }
 
         scope.$watch(function(scope){
-            return ngModelCtrl.$invalid && (scope.currentPageVisited || ngModelCtrl.$touched);
+            return ngModelCtrl.$invalid && (scope.currentPageVisited || ngModelCtrl.$touched || !!attrs.showErrorsInstant);
           },
           function(invalid){
             if(scope.inputs && scope.inputs.length >= 2){
               //if we are handling a group of inputs and any of the inputs are invalid and touched
               var groupInvalid = scope.inputs.some(function(currentValue){
-                  return currentValue.$invalid && (scope.currentPageVisited || currentValue.$touched);
+                  return currentValue.$invalid && (scope.currentPageVisited || currentValue.$touched || !!attrs.showErrorsInstant);
                 });
               element.toggleClass('has-no-error', !invalid);
               element.parents('.form-group').toggleClass('has-error', groupInvalid);

--- a/app/scripts/directives/stringToNumber.js
+++ b/app/scripts/directives/stringToNumber.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// From https://docs.angularjs.org/error/ngModel/numfmt#example
+
+angular.module('confRegistrationWebApp').directive('stringToNumber', function () {
+  return {
+    require: 'ngModel',
+    link: function (scope, element, attrs, ngModel) {
+      ngModel.$parsers.push(function (value) {
+        return '' + value;
+      });
+      ngModel.$formatters.push(function (value) {
+        return parseFloat(value);
+      });
+    }
+  };
+});

--- a/app/scripts/services/validateRegistrant.js
+++ b/app/scripts/services/validateRegistrant.js
@@ -12,13 +12,16 @@ angular.module('confRegistrationWebApp')
         var rule = block.rules[i];
         var answer = _.find(answers, { blockId: rule.parentBlockId });
         if (angular.isDefined(answer) && answer.value !== '') {
-          if (rule.operator === '=' && answer.value === rule.value) {
+          //If string is a number, parse it as a float for numerical comparison
+          var answerValue = !isNaN(answer.value) ? parseFloat(answer.value) : answer.value;
+          var ruleValue = !isNaN(rule.value) ? parseFloat(rule.value) : rule.value;
+          if (rule.operator === '=' && answerValue === ruleValue) {
             validRuleCount++;
-          } else if (rule.operator === '!=' && answer.value !== rule.value) {
+          } else if (rule.operator === '!=' && answerValue !== ruleValue) {
             validRuleCount++;
-          } else if (rule.operator === '>' && answer.value > rule.value) {
+          } else if (rule.operator === '>' && answerValue > ruleValue) {
             validRuleCount++;
-          } else if (rule.operator === '<' && answer.value < rule.value) {
+          } else if (rule.operator === '<' && answerValue < ruleValue) {
             validRuleCount++;
           }
         }
@@ -27,13 +30,9 @@ angular.module('confRegistrationWebApp')
         }
       }
 
-      if (block.rules.length === 0 || // If no rules are set
+      return block.rules.length === 0 || // If no rules are set
         (ruleOperand === 'OR' && validRuleCount > 0) ||
-        (ruleOperand === 'AND' && validRuleCount === block.rules.length)) {
-        return true;
-      } else {
-        return false;
-      }
+        (ruleOperand === 'AND' && validRuleCount === block.rules.length);
     };
 
     var blockInRegistrantType = function(block, registrant){

--- a/app/views/blocks/numberQuestion.html
+++ b/app/views/blocks/numberQuestion.html
@@ -1,2 +1,11 @@
-<input show-errors type="number" ng-model="answer.value" ng-required="block.required" class="form-control" ng-disabled="editBlock" />
-<span class="help-block help-block-hidden" translate>Please enter a number</span>
+<input show-errors
+       type="number"
+       class="form-control"
+       ng-model="answer.value"
+       ng-disabled="editBlock"
+       ng-required="block.required"
+       ng-min="block.content.range.min"
+       ng-max="block.content.range.max" />
+<span class="help-block help-block-hidden" ng-if="block.content.range.min && block.content.range.max" translate>Please enter a number between {{block.content.range.min}} and {{block.content.range.max}}</span>
+<span class="help-block help-block-hidden" ng-if="block.content.range.min && !block.content.range.max" translate>Please enter a number greater than or equal to {{block.content.range.min}}</span>
+<span class="help-block help-block-hidden" ng-if="!block.content.range.min && block.content.range.max" translate>Please enter a number less than or equal to {{block.content.range.max}}</span>

--- a/app/views/components/blockEditor.html
+++ b/app/views/components/blockEditor.html
@@ -31,7 +31,7 @@
     <select-question block="block" ng-switch-when="selectQuestion"></select-question>
     <name-question block="block" ng-switch-when="nameQuestion"></name-question>
     <address-question block="block" ng-switch-when="addressQuestion"></address-question>
-    <number-question block="block" ng-switch-when="numberQuestion"></number-question>
+    <number-question block="block" ng-switch-when="numberQuestion" class="form-group"></number-question>
     <gender-question block="block" ng-switch-when="genderQuestion"></gender-question>
     <date-question block="block" ng-switch-when="dateQuestion"></date-question>
     <year-in-school-question block="block" ng-switch-when="yearInSchoolQuestion"></year-in-school-question>
@@ -116,6 +116,18 @@
             <pick-a-date show-errors ng-model="block.content.range.max" ng-required="block.required" picker-min-date="block.content.range.min"></pick-a-date>
           </div>
         </div>
+        <div class="row" ng-if="block.type === 'numberQuestion'">
+          <div class="form-group col-sm-6 stacked-spacing-col-sm">
+            <label class="control-label" translate>Min Number</label>
+            <input show-errors type="number" class="form-control field-label" ng-model="block.content.range.min" ng-max="block.content.range.max">
+            <span class="help-block help-block-hidden" translate>Number is larger than the max value of {{block.content.range.max}}</span>
+          </div>
+          <div class="form-group col-sm-6 stacked-spacing-col-sm">
+            <label class="control-label" translate>Max Number</label>
+            <input show-errors type="number" class="form-control field-label" ng-model="block.content.range.max" ng-min="block.content.range.min">
+            <span class="help-block help-block-hidden" translate>Number is smaller than the min value of {{block.content.range.min}}</span>
+          </div>
+        </div>
         <div class="form-group">
           <label translate>Show this question for the following registrant types:</label>
           <div ng-if="canChangeRegTypes">
@@ -139,9 +151,9 @@
         </div>
         <div class="form-group" ng-if="hasOptions">
           <label class="inline-label" translate>Expense Type</label>
-             <select class="form-control" ng-model="block.expenseType" ng-options="key as value for (key , value) in expenseTypesConstants">
-              <option value="" translate>None</option>
-             </select>
+          <select class="form-control" ng-model="block.expenseType" ng-options="key as value for (key , value) in expenseTypesConstants">
+            <option value="" translate>None</option>
+          </select>
         </div>
       </tab>
       <tab heading="Rules" ng-if="canHaveRules">
@@ -165,11 +177,11 @@
             </div>
           </div>
 
-          <div ng-repeat="rule in block.rules" class="form-group">
-            <div class="col-md-4 stacked-spacing-col-md">
+          <div ng-repeat="rule in block.rules" style="overflow: auto">
+            <div class="col-md-4 stacked-spacing-col-md form-group">
               <select ng-model="rule.parentBlockId" ng-options="block.id as block.title for block in ruleBlocks()" class="form-control"></select>
             </div>
-            <div class="col-md-2 col-sm-5 stacked-spacing-col-md">
+            <div class="col-md-2 col-sm-5 stacked-spacing-col-md form-group">
               <select class="form-control" ng-model="rule.operator">
                 <option value="=" translate>equals</option>
                 <option value="!=" translate>does not equal</option>
@@ -177,14 +189,26 @@
                 <option value="<" ng-if="!ruleValues(rule.parentBlockId).length" translate>is less than</option>
               </select>
             </div>
-            <div class="col-md-5 col-sm-7 stacked-spacing-col-md">
-              <input type="text" ng-model="rule.value" ng-show="ruleValueInputType(rule.parentBlockId) === 'number'" class="form-control">
-              <select ng-model="rule.value" ng-options="v for v in ruleValues(rule.parentBlockId)" ng-show="ruleValueInputType(rule.parentBlockId) === 'select'" class="form-control"></select>
-              <select ng-model="rule.value" ng-show="ruleValueInputType(rule.parentBlockId) === 'gender'" class="form-control">
+            <div class="col-md-5 col-sm-7 stacked-spacing-col-md form-group" ng-switch="ruleValueInputType(rule.parentBlockId)">
+              <div ng-switch-when="number">
+                <input type="number"
+                       class="form-control"
+                       show-errors
+                       string-to-number
+                       ng-model="rule.value"
+                       ng-model-options="{ allowInvalid: true }"
+                       ng-min="{{ruleValues(rule.parentBlockId).min}}"
+                       ng-max="{{ruleValues(rule.parentBlockId).max}}" />
+                <span class="help-block help-block-hidden" ng-if="ruleValues(rule.parentBlockId).min && ruleValues(rule.parentBlockId).max" translate>Please enter a number between {{ruleValues(rule.parentBlockId).min}} and {{ruleValues(rule.parentBlockId).max}}</span>
+                <span class="help-block help-block-hidden" ng-if="ruleValues(rule.parentBlockId).min && !ruleValues(rule.parentBlockId).max" translate>Please enter a number greater than or equal to {{ruleValues(rule.parentBlockId).min}}</span>
+                <span class="help-block help-block-hidden" ng-if="!ruleValues(rule.parentBlockId).min && ruleValues(rule.parentBlockId).max" translate>Please enter a number less than or equal to {{ruleValues(rule.parentBlockId).max}}</span>
+              </div>
+              <select ng-switch-when="select" ng-model="rule.value" ng-options="v for v in ruleValues(rule.parentBlockId)" class="form-control"></select>
+              <select ng-switch-when="gender" ng-model="rule.value" class="form-control">
                 <option value="M" translate>Male</option>
                 <option value="F" translate>Female</option>
               </select>
-              <pick-a-date ng-model="rule.value" ng-if="ruleValueInputType(rule.parentBlockId) === 'date'" picker-min-date="getRangeValues(rule.parentBlockId).min" picker-max-date="getRangeValues(rule.parentBlockId).max"></pick-a-date>
+              <pick-a-date ng-switch-when="date" ng-model="rule.value" picker-min-date="getRangeValues(rule.parentBlockId).min" picker-max-date="getRangeValues(rule.parentBlockId).max"></pick-a-date>
             </div>
             <div class="clearfix visible-sm-block"></div>
             <div class="col-md-1 text-right">

--- a/app/views/components/blockEditor.html
+++ b/app/views/components/blockEditor.html
@@ -119,12 +119,12 @@
         <div class="row" ng-if="block.type === 'numberQuestion'">
           <div class="form-group col-sm-6 stacked-spacing-col-sm">
             <label class="control-label" translate>Min Number</label>
-            <input show-errors type="number" class="form-control field-label" ng-model="block.content.range.min" ng-max="block.content.range.max">
+            <input show-errors show-errors-instant="true" type="number" class="form-control field-label" ng-model="block.content.range.min" ng-max="block.content.range.max">
             <span class="help-block help-block-hidden" translate>Number is larger than the max value of {{block.content.range.max}}</span>
           </div>
           <div class="form-group col-sm-6 stacked-spacing-col-sm">
             <label class="control-label" translate>Max Number</label>
-            <input show-errors type="number" class="form-control field-label" ng-model="block.content.range.max" ng-min="block.content.range.min">
+            <input show-errors show-errors-instant="true" type="number" class="form-control field-label" ng-model="block.content.range.max" ng-min="block.content.range.min">
             <span class="help-block help-block-hidden" translate>Number is smaller than the min value of {{block.content.range.min}}</span>
           </div>
         </div>
@@ -194,6 +194,7 @@
                 <input type="number"
                        class="form-control"
                        show-errors
+                       show-errors-instant="true"
                        string-to-number
                        ng-model="rule.value"
                        ng-model-options="{ allowInvalid: true }"


### PR DESCRIPTION
This PR replaces https://github.com/CruGlobal/conf-registration-web/pull/497

- Add min and max inputs to Advanced tab of block editor
- Validate number input in rules section but allow invalid so updates to the number validation range don't cause api errors. The user can update it later.
- Add stringToNumber directive and casting to blockVisibleRuleCheck since rules are stored as strings

@jayakrishnanv What do you think of this? I was trying to make sure it worked and show you an example but I just ended up implementing it all. I started with your code but got rid of all the custom validation and DOM manipulation. The validation wasn't too bad but I spent a while trying to fix the rules so they would compare numbers as numbers instead of strings which I assume is a long standing bug. Let me know if you see any cases where this doesn't work or if you have any improvements.

It might need some code to interact with the default value feature correctly

@hlbraddock How easy would it be to convert `rule.value` to a number in the api? I got it to work  as a string but it is more code than it needs to be. If it's not trivial, don't worry about it.