### PR TITLE
Update moment-timezone dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "angular-route": "1.3.15",
     "lodash": "~2.4.1",
     "moment": "~2.10.5",
-    "moment-timezone": "~0.2.2",
+    "moment-timezone": "~0.5.11",
     "bootstrap": "~3.3.4",
     "angular-bootstrap": "0.13.0",
     "eonasdan-bootstrap-datetimepicker": "^4.17.43",


### PR DESCRIPTION
Update the `moment-timezone` dependency to remove deprecation warnings about `moment().zone`.