### PR TITLE
Use device ID from server

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -290,17 +290,14 @@ angular.module('confRegistrationWebApp', ['ngRoute', 'ngCookies', 'ngSanitize', 
       vars: {
         development: {
           apiUrl: 'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
-          tsysDeviceId: '88812128320102',
           tsysEnvironment: 'staging'
         },
         staging: {
           apiUrl: 'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
-          tsysDeviceId: '88812128320102',
           tsysEnvironment: 'staging'
         },
         production: {
           apiUrl: 'https://api.eventregistrationtool.com/eventhub-api/rest/',
-          tsysDeviceId: '8487000661973802',
           tsysEnvironment: 'production'
         }
       }

--- a/app/scripts/services/payment.js
+++ b/app/scripts/services/payment.js
@@ -3,9 +3,9 @@
 angular.module('confRegistrationWebApp')
   .factory('payment', function ($q, $http, $filter, cruPayments, envService, error) {
     // Load the TSYS manifest
-    // Returns a promise that resolves to the manifest value
+    // Returns a promise that resolves to an object containing the manifest and device id
     function loadTsysManifest (payment) {
-      var url = 'payments/manifest/' + envService.read('tsysDeviceId');
+      var url = 'payments/appManifest';
       return $http.get(url, { data: payment }).then(function (res) {
         return res.data;
       });
@@ -30,8 +30,8 @@ angular.module('confRegistrationWebApp')
         .then(function () {
           return loadTsysManifest(payment);
         })
-        .then(function (manifest) {
-          cruPayments.init(envService.read('tsysEnvironment'), envService.read('tsysDeviceId'), manifest);
+        .then(function (appManifest) {
+          cruPayments.init(envService.read('tsysEnvironment'), appManifest.deviceId, appManifest.manifest);
           return cruPayments.encrypt(payment.creditCard.number, payment.creditCard.cvvNumber,
                                      payment.creditCard.expirationMonth, payment.creditCard.expirationYear).toPromise();
         })

--- a/app/scripts/services/payment.js
+++ b/app/scripts/services/payment.js
@@ -38,7 +38,6 @@ angular.module('confRegistrationWebApp')
         .then(function (tokenizedCard) {
           payment.creditCard.lastFourDigits = tokenizedCard.maskedCardNumber;
           payment.creditCard.number = tokenizedCard.tsepToken;
-          payment.creditCard.cvvNumber = tokenizedCard.cvv2;
         })
         .catch(error.errorFromResponse('An error occurred while requesting the TSYS token. Please try your payment again.'));
     }

--- a/app/views/eventDetails/paymentOptions.html
+++ b/app/views/eventDetails/paymentOptions.html
@@ -12,9 +12,9 @@
         <translate>For information on obtaining a merchant account, please see your regional Financial Professional or Operations Director.</translate>
       </span>
       <span ng-if="conference.paymentGatewayType === 'TSYS'">
-        <translate>If you will be accepting credit card payments for your event, you must have a merchant account from a credit card processing vendor.</translate>
-        <translate>For information on obtaining a merchant account, please see your regional Financial Professional or Operations Director.</translate>
-        <translate>If you're not sure who your Financial Professional or Operations Director is or if you have other questions about setting up a merchant account with Cru, please contact financial.services@cru.org.</translate>
+        <translate>If accepting credit card payments for your event, you will need a merchant account from a credit card processing vendor.</translate>
+        <translate>For details about an existing merchant account, contact your team's finance/operations leader.</translate>
+        <translate>For a new merchant account, email merchant.account@cru.org with your request.</translate>
       </span>
     </p>
     <div class="form-group">

--- a/app/views/eventDetails/paymentOptions.html
+++ b/app/views/eventDetails/paymentOptions.html
@@ -17,9 +17,6 @@
         <translate>If you're not sure who your Financial Professional or Operations Director is or if you have other questions about setting up a merchant account with Cru, please contact financial.services@cru.org.</translate>
       </span>
     </p>
-    <p translate>
-      Using <strong>{{paymentGateways[conference.paymentGatewayType].name}}</strong> for credit card processing.
-    </p>
     <div class="form-group">
       <div class="col-sm-6 stacked-spacing-above-col-sm" ng-show="conference.paymentGatewayKeySaved">
         <label translate>{{paymentGateways[conference.paymentGatewayType].fields.paymentGatewayId.title}}:</label>


### PR DESCRIPTION
Instead of hard-coding the device ID on the client, the server now hard-codes the device ID and sends it to the client along with the TSYS manifest.