### PR TITLE
Disallow pages on HTTP or not on a subdomain

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,6 +14,8 @@
     </script>
   <![endif]>
 
+  <script src="scripts/clientSideRedirection.js"></script>
+
   <!-- Adobe DTM -->
   <!-- build:remove:dist -->
   <script src="//assets.adobedtm.com/3202ba9b02b459ee20779cfcd8e79eaf266be170/satelliteLib-928beaae1bce68f8836cc63dd18a9951aa3a1f4e-staging.js"></script>

--- a/app/scripts/clientSideRedirection.js
+++ b/app/scripts/clientSideRedirection.js
@@ -1,0 +1,27 @@
+'use strict';
+
+(function () {
+  // Do not redirect from localhost
+  if (window.location.hostname === 'localhost') {
+    return;
+  }
+
+  /*
+   * Perform client-side redirection. The following hostname/protocol combinations must be redirected:
+   * http://stage.eventregistrationtool.com --> https://stage.eventregistrationtool.com
+   * http://www.eventregistrationtool.com --> https://www.eventregistrationtool.com
+   * http://eventregistrationtool.com --> https://www.eventregistrationtool.com
+   * https://eventregistrationtool.com --> https://www.eventregistrationtool.com
+   */
+
+  // Redirect from eventregistrationtool.com to www.eventregistrationtool.com
+  var newHostname = window.location.hostname === 'eventregistrationtool.com' ? 'www.eventregistrationtool.com' : window.location.hostname;
+
+  // Redirect from http to https
+  var newOrigin = 'https://' + newHostname;
+
+  // Navigate to the new origin if it changed
+  if (newOrigin !== window.location.origin) {
+    window.location.replace(newOrigin + window.location.pathname + window.location.search + window.location.hash);
+  }
+})();


### PR DESCRIPTION
Ensure that in staging and production, the SPA is running on an SSL-secured page and that it is not running on the raw `eventregistrationtool.com` domain because our SSL certificate is not valid for that domain.