### PR TITLE
Explicitly name Authorize.NET on Payment Options page

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -29,8 +29,8 @@ angular.module('confRegistrationWebApp')
       AUTHORIZE_NET: {
         name: gettextCatalog.getString('Authorize.Net'),
         fields: {
-          paymentGatewayId: { title: gettextCatalog.getString('Account ID') },
-          paymentGatewayKey: { title: gettextCatalog.getString('Key') }
+          paymentGatewayId: { title: gettextCatalog.getString('Authorize.NET Account ID') },
+          paymentGatewayKey: { title: gettextCatalog.getString('Authorize.NET Key') }
         }
       },
       TSYS: {

--- a/app/views/eventDetails/paymentOptions.html
+++ b/app/views/eventDetails/paymentOptions.html
@@ -8,7 +8,7 @@
     <p class="text-muted">
       <i class="fa fa-info-circle"></i>
       <span ng-if="conference.paymentGatewayType === 'AUTHORIZE_NET'">
-        <translate>If you will be accepting credit card payments for your event, you must have a merchant account from a credit card processing vendor.</translate>
+        <translate>If you will be accepting credit card payments for your event, you must have an Authorize.NET merchant account from a credit card processing vendor.</translate>
         <translate>For information on obtaining a merchant account, please see your regional Financial Professional or Operations Director.</translate>
       </span>
       <span ng-if="conference.paymentGatewayType === 'TSYS'">


### PR DESCRIPTION
This clarity is provided in order that conference administrators not attempt to add a merchant id as Authorize.NET credentials.
