### PR TITLE
Specify $q as Promise implementation for rxjs toPromise

### DIFF
--- a/app/scripts/services/payment.js
+++ b/app/scripts/services/payment.js
@@ -33,7 +33,7 @@ angular.module('confRegistrationWebApp')
         .then(function (appManifest) {
           cruPayments.init(envService.read('tsysEnvironment'), appManifest.deviceId, appManifest.manifest);
           return cruPayments.encrypt(payment.creditCard.number, payment.creditCard.cvvNumber,
-                                     payment.creditCard.expirationMonth, payment.creditCard.expirationYear).toPromise();
+                                     payment.creditCard.expirationMonth, payment.creditCard.expirationYear).toPromise($q);
         })
         .then(function (tokenizedCard) {
           payment.creditCard.lastFourDigits = tokenizedCard.maskedCardNumber;


### PR DESCRIPTION
We discovered with the new give site that `toPromise` falls back to the browser's native promise implementation which doesn't exist in IE.