### PR TITLE
Disable allowEditRegistrationAfterComplete by default as it conflicts…

### DIFF
--- a/app/scripts/services/ConfCache.js
+++ b/app/scripts/services/ConfCache.js
@@ -46,7 +46,7 @@ angular.module('confRegistrationWebApp')
       var data = {
         id: newConferenceId,
         name: name,
-        allowEditRegistrationAfterComplete: true,
+        allowEditRegistrationAfterComplete: false,
         combineSpouseRegistrations: false,
         registrationStartTime: moment().format('YYYY-MM-DD HH:mm:ss'),
         registrationEndTime: moment().add(14, 'days').format('YYYY-MM-DD HH:mm:ss'),


### PR DESCRIPTION
… with a requireLogin default setting

We could go the other way and default both of these to true if that's better but currently on the first save of the details page for a new conference, the user receives the "You must require sign in if allowing users to edit their registration after it's complete." error.