### PR TITLE
Fix discard changes redirect on leaving event details page

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -54,8 +54,9 @@ angular.module('confRegistrationWebApp')
       return $scope.conference.paymentGatewayType;
     };
 
-    $scope.$on('$locationChangeStart', function(event, newLocation) {
+    $scope.$on('$locationChangeStart', function(event) {
       if(!angular.equals(conference, $scope.conference)){
+        const newLocation = $location.path();
         event.preventDefault();
         modalMessage.confirm({
           title: 'Warning: Unsaved Changes',
@@ -65,7 +66,7 @@ angular.module('confRegistrationWebApp')
           normalSize: true
         }).then(function(){
           conference = angular.copy($scope.conference);
-          $location.url($location.url(newLocation).hash());
+          $location.path(newLocation);
         });
       }
     });


### PR DESCRIPTION
@dougworner Can you review this? You can reproduce this by going to the event details page, changing something, and then clicking a link to go to another page. It was redirecting to the home page instead of the desired page.

I saw this solution https://stackoverflow.com/a/31061068/665224