### PR TITLE
Add ability for a conference to specify a custom CSS file for their r…

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -36,6 +36,7 @@
 </head>
 
 <body ng-class="globalPage.bodyClass" ng-cloak>
+<link ng-if="globalPage.conference.cssUrl" ng-href="{{globalPage.conference.cssUrl}}" rel="stylesheet">
 <% if(!htmlWebpackPlugin.options.prod) { %>
 <div class="row previewRow">
   <div class="col-xs-12" style="font-size:24px;">

--- a/app/views/eventDetails/regOptions.html
+++ b/app/views/eventDetails/regOptions.html
@@ -59,3 +59,15 @@
     <input type="text" class="form-control" placeholder="www.example.com" ng-model="conference.registrationCompleteRedirect">
   </div>
 </div>
+
+<div class="form-group">
+  <div class="col-sm-12">
+    <label class="control-label" translate>Custom CSS stylesheet</label>
+    <i class="question-popover fa fa-question-circle"
+       uib-popover="{{'Allows for custom styling of the registration pages. This CSS file will be applied to the registration pages for your conference. It has no effect on the admin pages or home page. Must be hosted at an https:// url and have a .css file extension.' | translate}}"
+       popover-trigger="mouseenter"
+       popover-append-to-body="true">
+    </i>
+    <input type="text" class="form-control" placeholder="https://www.example.com/custom.css" ng-model="conference.cssUrl" show-errors ng-pattern="/^https?:\/\/.+\..+\/.+\.css$/">
+  </div>
+</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,7 @@ module.exports = env => {
           new FaviconsWebpackPlugin('./app/img/favicon.png'),
           new SriPlugin({
             hashFuncNames: ['sha512']
-          }),
+          })
         ] : [],
       env.analyze ? [ new BundleAnalyzerPlugin() ] : []
 


### PR DESCRIPTION
…egistration pages

~~This doesn't have API support yet so the key name in the conference object may need to be changed.~~ Updated to match https://github.com/CruGlobal/ert-api/pull/721

FamilyLife wants to iFrame the ERT form on their conference info page and needs it to be custom branded. They are working on writing CSS overrides.