### PR TITLE
Update additional cost language

### DIFF
--- a/app/views/modals/choiceOptions.html
+++ b/app/views/modals/choiceOptions.html
@@ -16,7 +16,7 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <p class="text-muted"><i class="fa fa-info-circle"></i> <span translate>If the registrant selects this option, the total cost can be adjusted. Example: A t-shirt could add an additional $5 to the cost.</span></p>
+      <p class="text-muted"><i class="fa fa-info-circle"></i> <span translate>If the registrant selects this option, the total cost can be adjusted. Example: A book could add an additional $5 to the cost.</span></p>
     </div>
   </div>
 </div>

--- a/languages/ert.pot
+++ b/languages/ert.pot
@@ -944,7 +944,7 @@ msgid "If registered by"
 msgstr ""
 
 #: ./app/views/modals/choiceOptions.html:19
-msgid "If the registrant selects this option, the total cost can be adjusted. Example: A t-shirt could add an additional $5 to the cost."
+msgid "If the registrant selects this option, the total cost can be adjusted. Example: A book could add an additional $5 to the cost."
 msgstr ""
 
 #: ./app/views/registration.html:36


### PR DESCRIPTION
Due to recent changes with FSG, the example of "t-shirt" is no longer acceptable.