### PR TITLE
Remove option for admin to submit credit card payment.

### DIFF
--- a/app/views/modals/paymentsModal.html
+++ b/app/views/modals/paymentsModal.html
@@ -436,7 +436,6 @@
           <select ng-model="newTransaction.paymentType" class="form-control" ng-change="setTransactionAmount()">
             <option value="" disabled selected translate>Choose one...</option>
             <optgroup label="Payment">
-              <option value="CREDIT_CARD" ng-if="conference.paymentGatewayKeySaved" translate>Credit Card</option>
               <option value="OFFLINE_CREDIT_CARD" translate>Offline Credit Card</option>
               <option value="SCHOLARSHIP" translate>Scholarship</option>
               <option value="TRANSFER" translate>Account Transfer</option>


### PR DESCRIPTION
This is required as PCI Compliance regulations do not allow entering of credit card numbers directly into applications (i.e. ERT) on devices not owned by the credit card holder.