### PR TITLE
EVENT-532 - Default to Profile Question Checked

### DIFF
--- a/app/scripts/controllers/angularUiTreeConfig.js
+++ b/app/scripts/controllers/angularUiTreeConfig.js
@@ -10,7 +10,7 @@ angular.module('confRegistrationWebApp')
         if(event.dest.nodesScope.$nodeScope){ //prevents error from dropping on source tree
           var block = event.source.nodeScope.$modelValue;
           var pageId = event.dest.nodesScope.$nodeScope.$modelValue.id;
-          $scope.insertBlock(block.id, pageId, event.dest.index, block.defaultTitle);
+          $scope.insertBlock(block.id, pageId, event.dest.index, block.defaultTitle, block.defaultProfile);
         }
         return false; //cancel regular drop action
       }


### PR DESCRIPTION
For profile questions, they should default to checked for being saved to the profile. I dug in and found that the `defaultProfile` value was not being passed in when dropping a new question onto the form, and thus, every question defaulted to not being a profile question.