### PR TITLE
Improve NONE auth provider type expiration

### DIFF
--- a/app/scripts/services/unauthorizedInterceptor.js
+++ b/app/scripts/services/unauthorizedInterceptor.js
@@ -1,10 +1,14 @@
 
 angular.module('confRegistrationWebApp')
-  .factory('unauthorizedInterceptor', function ($q, $cookies, loginDialog) {
+  .factory('unauthorizedInterceptor', function ($window, $q, $cookies, envService, loginDialog) {
     return {
       responseError: function (rejection) {
         if (rejection.status === 401 && angular.isDefined($cookies.get('crsToken'))) {
-          loginDialog.show(true);
+          if($cookies.get('crsAuthProviderType') === 'NONE') {
+            $window.location.href = envService.read('apiUrl') + 'auth/none/login';
+          }else{
+            loginDialog.show(true);
+          }
         }
         return $q.reject(rejection);
       }

--- a/app/views/modals/loginDialog.html
+++ b/app/views/modals/loginDialog.html
@@ -23,8 +23,7 @@
     </div>
     <p class="spacing-above-sm">
       <span class="text-muted">or</span>
-      <a ng-if="!status401" href="" ng-click="gotoRoute('/')" translate>go to the Welcome Page</a>
-      <a ng-if="status401" href="" ng-click="gotoRoute('/eventDashboard')" translate>go to Event Dashboard</a>
+      <a href="" ng-click="gotoRoute('/')" translate>go to the Welcome Page</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
- Remove link to eventDashboard when unauthorized. Navigating there doesn't make sense if you aren't logged in and the user can end up in a loop. Prevents `intendedRoute` from being changed.
- Re-auth if cookie expires for NONE auth type. Prevents anonymous users from being forced to login with loginDialog

I'm trying to make it better for the people dealing with session expiration in https://secure.helpscout.net/conversation/550303594/206163/. I'm not quite sure what they are encountering but it sounds like session expiration. Hopefully these help. Let me know if you see any issues that might come up with making these changes or if I made any bad assumptions.