### PR TITLE
EVENT-544: Add cookie domain to share session cookies between www and…

### DIFF
--- a/app/scripts/app.config.js
+++ b/app/scripts/app.config.js
@@ -12,7 +12,7 @@ import helpTemplate from 'views/help.html';
 import privacyTemplate from 'views/privacy.html';
 
 angular.module('confRegistrationWebApp')
-  .config(function ($locationProvider, $httpProvider, $qProvider, $routeProvider, envServiceProvider, $compileProvider, gettext) {
+  .config(function ($locationProvider, $httpProvider, $qProvider, $routeProvider, envServiceProvider, $compileProvider, $cookiesProvider, gettext) {
     $locationProvider.html5Mode(true).hashPrefix('');
     $httpProvider.useApplyAsync(true);
     $qProvider.errorOnUnhandledRejections(false);
@@ -32,21 +32,26 @@ angular.module('confRegistrationWebApp')
       vars: {
         development: {
           apiUrl: 'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
-          tsysEnvironment: 'staging'
+          tsysEnvironment: 'staging',
+          cookieDomain: 'localhost'
         },
         staging: {
           apiUrl: 'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
-          tsysEnvironment: 'production'
+          tsysEnvironment: 'production',
+          cookieDomain: 'stage.eventregistrationtool.com'
         },
         production: {
           apiUrl: 'https://api.eventregistrationtool.com/eventhub-api/rest/',
-          tsysEnvironment: 'production'
+          tsysEnvironment: 'production',
+          cookieDomain: 'eventregistrationtool.com'
         }
       }
     });
 
     // Determine which environment we are running in
     envServiceProvider.check();
+
+    $cookiesProvider.defaults.domain = envServiceProvider.read('cookieDomain');
 
     if (envServiceProvider.is('production') || envServiceProvider.is('staging')) {
       $compileProvider.debugInfoEnabled(false);

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.3",
     "ngtemplate-loader": "^2.0.0",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.9.0",
     "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "^2.1.14",
     "sass-loader": "^6.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,6 +2893,16 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -4557,7 +4567,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0, nan@^2.3.2:
+nan@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
@@ -4683,9 +4697,9 @@ node-rest-client@^1.5.1:
     debug "~2.2.0"
     xml2js ">=0.2.4"
 
-node-sass@^4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
+node-sass@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -4699,12 +4713,13 @@ node-sass@^4.5.3:
     lodash.mergewith "^4.6.0"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.3.2"
+    nan "^2.10.0"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
-    request "^2.79.0"
-    sass-graph "^2.1.1"
+    request "~2.79.0"
+    sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
 
 node-status-codes@^1.0.0:
   version "1.0.0"
@@ -5787,7 +5802,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@^2.65.0, request@^2.79.0, request@^2.81.0:
+request@2, request@^2.65.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5949,7 +5964,7 @@ safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
-sass-graph@^2.1.1:
+sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
   dependencies:
@@ -6633,6 +6648,12 @@ trim-right@^1.0.1:
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+"true-case-path@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.2.tgz#7ec91130924766c7f573be3020c34f8fdfd00d62"
+  dependencies:
+    glob "^6.0.4"
 
 tryit@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
… apex domains

- Upgrade node-sass

https://jira.cru.org/browse/EVENT-544

The node-sass upgrade isn't necessary but I had to recompile it locally for node 10 and it grabbed a new version so I left it.

I was considering the redirect to www but it looks like to do it with AWS, you'd have to create an S3 bucket for that apex domain for the entire purpose of the redirect and get Cloudfront to apply HTTPS to it somehow. Seemed too convoluted.

This just sets the domain of all cookies set by the client to the apex domain so they can be shared between the apex domain and the www subdomain.

I think that regex test line was functioning properly and the sourcemap was weird. It compiles to `/^\/auth\/.*/.test(a.url()) || (t.put("intendedRoute", a.path()), ...`.