### PR TITLE
MHP-544: Add error handling to auth route's profile request

### DIFF
--- a/app/scripts/app.config.js
+++ b/app/scripts/app.config.js
@@ -241,15 +241,23 @@ angular.module('confRegistrationWebApp')
               $cookies.put('crsAuthProviderType', '');
               $cookies.put('crsToken', $route.current.params.token);
               $rootScope.crsToken = $cookies.get('crsToken');
-              ProfileCache.getCache().then(function (data) {
-                $cookies.put('crsAuthProviderType', data.authProviderType);
-                if(angular.isDefined($cookies.get('regType'))) {
-                  $location.path($cookies.get('intendedRoute') || '/').search('regType', $cookies.get('regType')).replace();
-                  $cookies.remove('regType');
-                } else {
-                  $location.path($cookies.get('intendedRoute') || '/').replace();
-                }
-              });
+              ProfileCache.getCache()
+                .then(function (data) {
+                  $cookies.put('crsAuthProviderType', data.authProviderType);
+                })
+                .catch(() => {
+                  $cookies.remove('crsToken');
+                  $cookies.remove('crsToken', { domain: 'eventregistrationtool.com'} );
+                  $cookies.remove('crsToken', { domain: 'www.eventregistrationtool.com'} );
+                })
+                .finally(() => {
+                  if(angular.isDefined($cookies.get('regType'))) {
+                    $location.path($cookies.get('intendedRoute') || '/').search('regType', $cookies.get('regType')).replace();
+                    $cookies.remove('regType');
+                  } else {
+                    $location.path($cookies.get('intendedRoute') || '/').replace();
+                  }
+                });
             }
           ]
         }


### PR DESCRIPTION
- Delete cookies on error and redirect to intended route

There is a potential the user could end up in a login loop if the intended route keeps taking them back to where they were that needed to login. But I think this strategy is better than just leaving them at a blank page. Let me know if you guys can think of any other strategies/improvements.

We still have the issue of the intendedRoute being set on both eventregistrationtool.com and www.eventregistrationtool.com and it reading the wrong one once login redirects to www. @adammeyer do you have any suggestions of how to solve that? My cookie PR failed... I could add back the [client side redirect to www](https://github.com/CruGlobal/conf-registration-web/pull/541/files#diff-a23f310732a5bb12ce55e68685d2df99) or make another S3 bucket to do redirects.

I've pushed this to staging.