### PR TITLE
MHP-544: Perform clientside redirection from apex production domain t…

### DIFF
--- a/app/scripts/clientSideRedirection.js
+++ b/app/scripts/clientSideRedirection.js
@@ -1,0 +1,22 @@
+// Do not redirect from localhost
+if (window.location.hostname !== 'localhost') {
+
+  /*
+   * Perform client-side redirection. The following hostname/protocol combinations must be redirected:
+   * https://eventregistrationtool.com --> https://www.eventregistrationtool.com
+   *
+   * http to https is handled by Cloudfront
+   * We are redirecting to www here in order to prevent cookie sharing issues across domains, especially related to intendedRoute
+   */
+
+  // Redirect from eventregistrationtool.com to www.eventregistrationtool.com
+  const newHostname = window.location.hostname === 'eventregistrationtool.com' ? 'www.eventregistrationtool.com' : window.location.hostname;
+
+  // Redirect from http to https
+  const newOrigin = 'https://' + newHostname;
+
+  // Navigate to the new origin if it changed
+  if (newOrigin !== window.location.origin) {
+    window.location.replace(newOrigin + window.location.pathname + window.location.search + window.location.hash);
+  }
+}

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,3 +1,4 @@
+import 'scripts/clientSideRedirection.js';
 import 'scripts/app.module.js';
 import 'scripts/app.config.js';
 import 'scripts/app.run.js';


### PR DESCRIPTION
…o www

We had this code before. I didn't think it was needed since Cloudflare handled the https redirect. I wish Cloudfront/S3 could handle this without creating more buckets. It would be nice to support the apex domain and www but the `intendedRoute` cookie isn't shared and auth redirects are broken when moving between domains.