### PR TITLE
EVENT-550 Change the word 'Family' to 'Group' on the UI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .idea
 coverage
+package-lock.json

--- a/app/views/eventDetails/regOptions.html
+++ b/app/views/eventDetails/regOptions.html
@@ -29,7 +29,7 @@
         <translate>Allow users to modify their registration after it is complete</translate>
       </label>
       <i class="question-popover fa fa-question-circle"
-         uib-popover="{{'This includes editing answers and adding family members.' | translate}}"
+         uib-popover="{{'This includes editing answers and adding group members.' | translate}}"
          popover-trigger="mouseenter"
          popover-append-to-body="true">
       </i>
@@ -40,7 +40,7 @@
         <translate>Combine spouse registrations</translate>
       </label>
       <i class="question-popover fa fa-question-circle"
-         uib-popover="{{'Combining spouse registrations will force a husband and wife to be on the same family registration instead of on two separate registrations. Note that the first spouse must register as a registrant type that allows family members for this option to have any effect.' | translate}}"
+         uib-popover="{{'Combining spouse registrations will force a husband and wife to be on the same group registration instead of on two separate registrations. Note that the first spouse must register as a registrant type that allows group members for this option to have any effect.' | translate}}"
          popover-trigger="mouseenter"
          popover-append-to-body="true">
       </i>

--- a/app/views/eventDetails/regTypes.html
+++ b/app/views/eventDetails/regTypes.html
@@ -61,7 +61,7 @@
                 <input type="number" class="form-control" ng-show="type.useLimit" ng-model="type.numberSlotsLimit">
               </div>
 
-              <h4 translate>Family Registration</h4>
+              <h4 translate>Group Registration</h4>
               <div class="radio">
                 <label>
                   <input type="radio" ng-model="type.familyStatus" value="DISABLED"  ng-disabled="disableField('groupSubRegistrantType', type.defaultTypeKey)">
@@ -79,7 +79,7 @@
                   <translate>Yes - Primary</translate>
                 </label>
                 <i class="question-popover fa fa-question-circle"
-                   uib-popover="{{'When selected, the user will be permitted to add more registrants (e.g. a spouse or child) to the registration.' | translate}}"
+                   uib-popover="{{'When selected, the user will be permitted to add more registrants (e.g. a spouse, child, student) to the registration.' | translate}}"
                    popover-trigger="mouseenter"
                    popover-append-to-body="true">
                 </i>
@@ -90,7 +90,7 @@
                   <translate>Yes - Dependent</translate>
                 </label>
                 <i class="question-popover fa fa-question-circle"
-                   uib-popover="{{'When selected, this type will not become available until at least one registrant which has \'Family Registrations\' set to \'Yes - Primary\' has been added to the registration.' | translate}}"
+                   uib-popover="{{'When selected, this type will not become available until at least one registrant which has \'Group Registration\' set to \'Yes - Primary\' has been added to the registration.' | translate}}"
                    popover-trigger="mouseenter"
                    popover-append-to-body="true">
                 </i>

--- a/app/views/reviewRegistration.html
+++ b/app/views/reviewRegistration.html
@@ -73,7 +73,7 @@
       </table>
     </section>
     <section ng-if="allowGroupRegistration && (!currentRegistration.completed || conference.allowEditRegistrationAfterComplete)" class="hidden-print">
-      <h2 class="page-title border" translate>Add a Family Member</h2>
+      <h2 class="page-title border" translate>Add a Group Member</h2>
       <registration-type-select></registration-type-select>
     </section>
     <section>

--- a/languages/ert.pot
+++ b/languages/ert.pot
@@ -122,7 +122,7 @@ msgid "Add User"
 msgstr ""
 
 #: ./app/views/reviewRegistration.html:76
-msgid "Add a Family Member"
+msgid "Add a Group Member"
 msgstr ""
 
 #: ./app/views/modals/addRegistrantType.html:6
@@ -440,7 +440,7 @@ msgid "Combine spouse registrations"
 msgstr ""
 
 #: ./app/views/eventDetails/regOptions.html:43
-msgid "Combining spouse registrations will force a husband and wife to be on the same family registration instead of on two separate registrations. Note that the first spouse must register as a registrant type that allows family members for this option to have any effect."
+msgid "Combining spouse registrations will force a husband and wife to be on the same group registration instead of on two separate registrations. Note that the first spouse must register as a registrant type that allows group members for this option to have any effect."
 msgstr ""
 
 #: ./app/views/eventRegistrations.html:164
@@ -813,7 +813,7 @@ msgid "Export Title"
 msgstr ""
 
 #: ./app/views/eventDetails/regTypes.html:64
-msgid "Family Registration"
+msgid "Group Registration"
 msgstr ""
 
 #: ./app/views/components/rule.html:47
@@ -1984,7 +1984,7 @@ msgid "This event does not contain any promotions."
 msgstr ""
 
 #: ./app/views/eventDetails/regOptions.html:32
-msgid "This includes editing answers and adding family members."
+msgid "This includes editing answers and adding group members."
 msgstr ""
 
 #: ./app/views/eventDetails/contactInfo.html:2
@@ -2165,7 +2165,7 @@ msgid "West Virginia"
 msgstr ""
 
 #: ./app/views/eventDetails/regTypes.html:82
-msgid "When selected, the user will be permitted to add more registrants (e.g. a spouse or child) to the registration."
+msgid "When selected, the user will be permitted to add more registrants (e.g. a spouse, child, student) to the registration."
 msgstr ""
 
 #: ./app/views/eventDetails/regTypes.html:71
@@ -2173,7 +2173,7 @@ msgid "When selected, the user will not be given the option to add more people t
 msgstr ""
 
 #: ./app/views/eventDetails/regTypes.html:93
-msgid "When selected, this type will not become available until at least one registrant which has 'Family Registrations' set to 'Yes - Primary' has been added to the registration."
+msgid "When selected, this type will not become available until at least one registrant which has 'Group Registration' set to 'Yes - Primary' has been added to the registration."
 msgstr ""
 
 #: ./app/views/eventDetails/paymentOptions.html:119


### PR DESCRIPTION
Change the word 'Family' to 'Group' on the UI.
This shows up in multiple places including on the Registrant Types page. It affects the tooltips as well on that page.

See https://jira.cru.org/browse/EVENT-550