### PR TITLE
EVENT-654: Fixes for check number for check payments

### DIFF
--- a/app/scripts/controllers/paymentModal.js
+++ b/app/scripts/controllers/paymentModal.js
@@ -251,6 +251,10 @@ angular
       }
       if (payment.paymentType === 'CHECK') {
         payment.status = 'RECEIVED';
+        if (!payment.check.checkNumber) {
+          modalMessage.error('Please enter a check number.');
+          return;
+        }
       }
 
       $http

--- a/app/scripts/directives/payment.js
+++ b/app/scripts/directives/payment.js
@@ -296,7 +296,10 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function() {
                   if (!currentPayment.status) {
                     paymentErrors.push('Please select a check status.');
                   }
-                  if (!currentPayment.check.checkNumber) {
+                  if (
+                    !currentPayment.check.checkNumber &&
+                    currentPayment.status === 'RECEIVED'
+                  ) {
                     paymentErrors.push('Please enter a check number.');
                   }
                 }

--- a/test/spec/controllers/paymentModal.spec.js
+++ b/test/spec/controllers/paymentModal.spec.js
@@ -26,7 +26,18 @@ describe('Controller: paymentModal', function() {
     }),
   );
 
+  var errorModal;
+  beforeEach(inject(function(_modalMessage_) {
+    errorModal = spyOn(_modalMessage_, 'error');
+  }));
+
   it('canBeRefunded should return true', function() {
     expect(scope.canBeRefunded(scope.registration.pastPayments[0])).toBe(true);
+  });
+
+  it('savePaymentEdits should validate chect number', function() {
+    let payment = { paymentType: 'CHECK', status: 'RECEIVED', check: {} };
+    scope.savePaymentEdits(payment);
+    expect(errorModal).toHaveBeenCalledWith('Please enter a check number.');
   });
 });

--- a/test/spec/controllers/paymentModal.spec.js
+++ b/test/spec/controllers/paymentModal.spec.js
@@ -26,8 +26,8 @@ describe('Controller: paymentModal', function() {
     }),
   );
 
-  var errorModal;
-  beforeEach(inject(function(_modalMessage_) {
+  let errorModal;
+  beforeEach(inject(_modalMessage_ => {
     errorModal = spyOn(_modalMessage_, 'error');
   }));
 
@@ -35,7 +35,7 @@ describe('Controller: paymentModal', function() {
     expect(scope.canBeRefunded(scope.registration.pastPayments[0])).toBe(true);
   });
 
-  it('savePaymentEdits should validate chect number', function() {
+  it('savePaymentEdits should validate chect number', () => {
     let payment = { paymentType: 'CHECK', status: 'RECEIVED', check: {} };
     scope.savePaymentEdits(payment);
     expect(errorModal).toHaveBeenCalledWith('Please enter a check number.');


### PR DESCRIPTION
1) Do not require check number if status is not 'RECEIVED'
1) Require check number on update payment if status is 'RECEIVED' (it is always set 'RECEIVED' on update)

See https://jira.cru.org/browse/EVENT-654 (subtask of https://jira.cru.org/browse/EVENT-642)