### PR TITLE
Pass clientUrl to API during sign in to be redirected back after

### DIFF
--- a/app/scripts/services/loginDialog.js
+++ b/app/scripts/services/loginDialog.js
@@ -13,6 +13,7 @@ angular
           envService,
         ) {
           $scope.apiUrl = envService.read('apiUrl');
+          $scope.clientUrl = window.location.origin;
           $scope.status401 = options.status401;
           $scope.relayLogin =
             options.relayLogin === undefined ? true : options.relayLogin;

--- a/app/views/modals/loginDialog.html
+++ b/app/views/modals/loginDialog.html
@@ -16,7 +16,7 @@
       <div ng-if="instagramLogin" class="{{ 'col-sm-6 col-sm-offset-3' }}">
         <a
           class="btn btn-subtle btn-block"
-          ng-href="{{apiUrl}}auth/instagram/authorization"
+          ng-href="{{apiUrl}}auth/instagram/authorization?clientUrl={{clientUrl}}"
           title="Instagram"
           ><img src="../../img/signin-instagram.jpeg"
         /></a>
@@ -27,7 +27,7 @@
       <div ng-if="facebookLogin" class="{{ 'col-sm-6 col-sm-offset-3' }}">
         <a
           class="btn btn-subtle btn-block"
-          ng-href="{{apiUrl}}auth/facebook/authorization"
+          ng-href="{{apiUrl}}auth/facebook/authorization?clientUrl={{clientUrl}}"
           title="Facebook"
           ><img src="../../img/signin-facebook.png"
         /></a>
@@ -38,7 +38,7 @@
       <div ng-if="relayLogin" class="{{ 'col-sm-6 col-sm-offset-3'}}">
         <a
           class="btn btn-subtle btn-block"
-          ng-href="{{apiUrl}}auth/relay/login?logoutCallbackUrl={{apiUrl}}auth/relay/logout&ticket=None"
+          ng-href="{{apiUrl}}auth/relay/login?clientUrl={{clientUrl}}&logoutCallbackUrl={{apiUrl}}auth/relay/logout&ticket=None"
           title="Relay"
           ><img src="../../img/signin-relay.png"
         /></a>


### PR DESCRIPTION
This works great for Relay 🎉  Thanks! It'll be much nicer to test PRs. You can test going through auth with the Netlify deploy status check below.

It doesn't seem to work for Facebook or Instagram 😞  Idk if that was intentional. They are hitting `auth/<provider>/authorization` unlike Relay which is hitting `auth/relay/login` if you missed applying this to that endpoint.