### PR TITLE
LocalizedCurrencyFilter_Fix

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -79,11 +79,18 @@ angular
     $scope.conference = angular.copy(conference);
     $scope.currencies = currencies;
 
-    // If by chance the conference currency code doesn't exist
+    // If by chance the conference currency or currency code doesn't exist
     // Set the default to USD.
-    if (!$scope.conference.currency.currencyCode) {
-      $scope.conference.currency.currencyCode = 'USD';
-      $scope.saveEvent();
+    if (
+      !$scope.conference.currency ||
+      !$scope.conference.currency.currencyCode
+    ) {
+      $scope.conference.currency = {
+        currencyCode: 'USD',
+        localeCode: 'en-US',
+        shortSymbol: '$',
+        name: 'US Dollar: English (United States)',
+      };
     }
 
     $scope.refreshAllowedRegistrantTypes = function() {

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -79,6 +79,13 @@ angular
     $scope.conference = angular.copy(conference);
     $scope.currencies = currencies;
 
+    // If by chance the conference currency code doesn't exist
+    // Set the default to USD.
+    if (!$scope.conference.currency.currencyCode) {
+      $scope.conference.currency.currencyCode = 'USD';
+      $scope.saveEvent();
+    }
+
     $scope.refreshAllowedRegistrantTypes = function() {
       $scope.conference.registrantTypes.forEach(type => {
         type.allowedRegistrantTypeSet = _.map(

--- a/app/scripts/filters/localizedCurrency.js
+++ b/app/scripts/filters/localizedCurrency.js
@@ -14,8 +14,13 @@ angular
   .module('confRegistrationWebApp')
   .filter('localizedSymbol', ($locale, $window) => {
     return currencyCode => {
+      let currentCurrencyCode = currencyCode ? currencyCode : 'USD';
       let localeId = $locale && $locale.id ? $locale.id : 'en-us';
-      let symbol = symbolFromFormatToParts(localeId, currencyCode, $window);
+      let symbol = symbolFromFormatToParts(
+        localeId,
+        currentCurrencyCode,
+        $window,
+      );
       if (symbol) {
         return symbol;
       }
@@ -23,7 +28,7 @@ angular
       return number
         .toLocaleString(localeId, {
           style: 'currency',
-          currency: currencyCode,
+          currency: currentCurrencyCode,
         })
         .replace(/[0., ]/g, '');
     };

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -45,6 +45,15 @@ describe('Controller: paymentModal', function() {
     }),
   );
 
+  it('Should set default currency to USD if it does not exist', () => {
+    expect(scope.conference.currency.currencyCode).toBe('USD');
+    expect(scope.conference.currency.localeCode).toBe('en-US');
+    expect(scope.conference.currency.shortSymbol).toBe('$');
+    expect(scope.conference.currency.name).toBe(
+      'US Dollar: English (United States)',
+    );
+  });
+
   it('changeTab() should change tab', function() {
     scope.changeTab('paymentOptions');
     expect(scope.activeTab).toBe('paymentOptions');


### PR DESCRIPTION
This is another fix for that same help scout ticket. Basically it seems some conferences didn't have their currencyCode set to the default 'USD' by the API. Lee is eventually going to make a check that will set it no matter what API Side, but for now to help the user we are doing it client side. 