### PR TITLE
FormatToParts-Fix 

### DIFF
--- a/app/scripts/filters/localizedCurrency.js
+++ b/app/scripts/filters/localizedCurrency.js
@@ -40,6 +40,13 @@ function symbolFromFormatToParts(localeId, currencyCode, window) {
   if (!('formatToParts' in numberFormat)) {
     return;
   }
-  return numberFormat.formatToParts().filter(e => e.type === 'currency')[0]
-    .value;
+  // Some browsers incorrectly return nan or Nan for the formatToParts function
+  // This will filter out all incorrect results.
+  const filteredSymbol = numberFormat
+    .formatToParts()
+    .filter(e => e.type !== 'nan' || e.value !== 'NaN');
+
+  if (filteredSymbol.length > 0) {
+    return filteredSymbol.filter(e => e.type === 'currency')[0].value;
+  }
 }


### PR DESCRIPTION
It seems some versions of safari are returning an array with an object `{type: 'nan", value: 'NaN'}` even though the correct values are being passed in. This just checks to see if any of those value exist in the array and then filters them out. Let me know if there is a cleaner way to do this.