### PR TITLE
EVENT-659: Date/Time stamp for ERT updates to a registration: answers and payments dates

### DIFF
--- a/app/scripts/controllers/eventRegistrations.js
+++ b/app/scripts/controllers/eventRegistrations.js
@@ -136,7 +136,6 @@ angular
         GroupId: false,
         Started: true,
         Completed: true,
-        LastUpdated: false,
       };
     } else {
       $scope.builtInColumnsVisible = JSON.parse(builtInColumnsVisibleInStorage);

--- a/app/scripts/controllers/eventRegistrations.js
+++ b/app/scripts/controllers/eventRegistrations.js
@@ -475,16 +475,29 @@ angular
       const registration = _.find($scope.registrations, {
         id: registrant.registrationId,
       });
+      const answersTimestamps = registrant.answers.map(
+        answer => answer.lastUpdatedTimestamp,
+      );
       if (
         $scope.isGroupRegistrant(registrant) &&
         registration.primaryRegistrantId !== registrant.id
       ) {
-        return registrant.lastUpdatedTimestamp;
+        const allTimestamps = [
+          ...answersTimestamps,
+          registrant.lastUpdatedTimestamp,
+        ].sort();
+        return allTimestamps[allTimestamps.length - 1];
       } else {
-        return registration.lastUpdatedTimestamp >
-          registrant.lastUpdatedTimestamp
-          ? registration.lastUpdatedTimestamp
-          : registrant.lastUpdatedTimestamp;
+        const paymentTimestamps = registration.pastPayments.map(
+          payment => payment.lastUpdatedTimestamp,
+        );
+        const allTimestamps = [
+          ...paymentTimestamps,
+          ...answersTimestamps,
+          registration.lastUpdatedTimestamp,
+          registrant.lastUpdatedTimestamp,
+        ].sort();
+        return allTimestamps[allTimestamps.length - 1];
       }
     };
 

--- a/app/views/eventRegistrations.html
+++ b/app/views/eventRegistrations.html
@@ -391,9 +391,7 @@
               width="160"
               ng-if="builtInColumnsVisible.LastUpdated"
             >
-              <a href="" ng-click="setOrder('last_updated_timestamp')" translate
-                >Last Updated</a
-              >
+              <translate>Last Updated</translate>
               <i
                 ng-if="queryParameters.orderBy === 'last_updated_timestamp'"
                 class="fa"

--- a/test/spec/controllers/eventRegistrations.spec.js
+++ b/test/spec/controllers/eventRegistrations.spec.js
@@ -140,10 +140,41 @@ describe('Controller: eventRegistrations', function() {
     }
   });
 
-  it('getRegistrationLastUpdatedTimestamp should return the latest of two dates for primary registrant of group registration', () => {
+  it('getRegistrationLastUpdatedTimestamp should return the latest of registrant/registration update date for primary registrant of group registration', () => {
     const registrant = testData.registration.registrants[0];
     const result_date = scope.getRegistrationLastUpdatedTimestamp(registrant);
     expect(result_date).toEqual('2015-07-10T15:06:05.383Z');
+  });
+
+  it('getRegistrationLastUpdatedTimestamp should consider answers for not primary registrant of group registration', () => {
+    const registrant = testData.registration.registrants[1];
+    registrant.answers[0].lastUpdatedTimestamp = '2017-07-10T15:06:05.383Z';
+
+    const result_date = scope.getRegistrationLastUpdatedTimestamp(registrant);
+    expect(result_date).toEqual('2017-07-10T15:06:05.383Z');
+  });
+
+  it('getRegistrationLastUpdatedTimestamp should consider answers for primary registrant of group registration', () => {
+    const registrant = angular.copy(testData.registration.registrants[0]);
+    registrant.answers[3].lastUpdatedTimestamp = '2017-07-10T15:06:05.383Z';
+    const result_date = scope.getRegistrationLastUpdatedTimestamp(registrant);
+    expect(result_date).toEqual('2017-07-10T15:06:05.383Z');
+  });
+
+  it('getRegistrationLastUpdatedTimestamp should consider payments for primary registrant of group registration', () => {
+    const registrant = testData.registration.registrants[0];
+    testData.registration.pastPayments[0].lastUpdatedTimestamp =
+      '2019-07-10T15:06:05.383Z';
+    const result_date = scope.getRegistrationLastUpdatedTimestamp(registrant);
+    expect(result_date).toEqual('2019-07-10T15:06:05.383Z');
+  });
+
+  it('getRegistrationLastUpdatedTimestamp should not consider payments for not primary registrant of group registration', () => {
+    const registrant = testData.registration.registrants[1];
+    testData.registration.pastPayments[0].lastUpdatedTimestamp =
+      '2019-07-10T15:06:05.383Z';
+    const result_date = scope.getRegistrationLastUpdatedTimestamp(registrant);
+    expect(result_date).toEqual('2012-12-21T10:23:33.494Z');
   });
 
   it("getRegistrationLastUpdatedTimestamp should return registrant's LastUpdatedTimestamp for not primary registrant of group registration", () => {

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -529,6 +529,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
           checkNumber: '234',
           checkType: null,
         },
+        lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
       },
     ],
     registrants: [
@@ -552,6 +553,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: '9b83eebd-b064-4edf-92d0-7982a330272a',
             value: 'M',
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '3a1cfe9d-e256-44e4-81fe-d4bea03d8e1c',
@@ -559,6 +561,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: '0556295a-3c4d-45b2-a00e-42b1fe199421',
             value: 235246,
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: 'd1c692b3-c1c4-4d18-8490-548e81a5a806',
@@ -566,6 +569,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: '0b876382-5fd1-46af-b778-10fc9b1b530d',
             value: '12',
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '60eef5c3-7e09-4b25-a03f-d330fb79ce7f',
@@ -573,6 +577,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: '2764e22b-8623-4c2b-81e5-f625574521f2',
             value: '1',
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '6e52f066-f894-43ac-b9c0-d195bb65443f',
@@ -582,6 +587,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
               '651': true,
             },
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '8c6be491-f956-4fd3-95ad-9b381b106278',
@@ -589,6 +595,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: 'e088fefc-eb9c-4904-b849-017facc9e063',
             value: 'test.person@cru.org',
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: 'c2cdfc82-5898-461c-ad15-438b49be7ca0',
@@ -599,6 +606,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
               lastName: 'Person',
             },
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '84666425-e587-40d5-afb6-d0824eda2f66',
@@ -606,6 +614,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: '26c09fa0-f62e-4dc4-a568-b061da6fdb09',
             value: '',
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             amount: 0,
@@ -619,6 +628,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
               state: 'NY',
               zip: '11111',
             },
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '84666425-e587-40d5-afb6-cccccccccccc',
@@ -626,6 +636,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: '18ccfb09-3006-4981-ab5e-aaaaaaaaaaaa',
             value: '',
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '6e52f066-f894-43ac-b9c0-aaaaaaffafaf',
@@ -637,6 +648,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
               C: true,
             },
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
           {
             id: '6e52f066-f894-43ac-b9c0-bfbfbfbfbfbf',
@@ -644,6 +656,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
             blockId: 'bd6cb777-563f-4975-a0c5-58030ee6c36c',
             value: {},
             amount: 0.0,
+            lastUpdatedTimestamp: '2001-07-10T15:06:05.383Z',
           },
         ],
         firstName: 'Test',
@@ -665,6 +678,16 @@ angular.module('confRegistrationWebApp').service('testData', function() {
         firstName: 'First',
         lastName: 'Last',
         email: 'example@host.com',
+        answers: [
+          {
+            id: 'd1c692b3-c1c4-4d18-8490-548e81a5a806',
+            registrantId: '6bd0f946-b010-4ef5-83f0-51c17449baf3',
+            blockId: '0b876382-5fd1-46af-b778-10fc9b1b530d',
+            value: '12',
+            amount: 0.0,
+            lastUpdatedTimestamp: '2007-07-10T15:06:05.383Z',
+          },
+        ],
       },
     ],
     expenses: [],
@@ -712,6 +735,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
           checkNumber: '234',
           checkType: null,
         },
+        lastUpdatedTimestamp: '2000-12-21T10:23:33.494Z',
       },
     ],
     registrants: [
@@ -730,6 +754,7 @@ angular.module('confRegistrationWebApp').service('testData', function() {
         firstName: 'First',
         lastName: 'Last',
         email: 'example@host.com',
+        answers: [],
       },
     ],
     expenses: [],


### PR DESCRIPTION
Note that this PR removes ability to order registration (registrant) by column `last_updated_timestamp` (here https://github.com/CruGlobal/conf-registration-web/pull/682/files#diff-d3e6e77ecaa193aab05dae909c31f0d6L394) since supporting this requires substantive front end changes, which were deemed not necessary at time of this release.