### PR TITLE
add-additional-meta-properties

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -8,6 +8,27 @@
       name="description"
       content="The Event Registration Tool provides everything you need when it comes to event registration and management."
     />
+    <meta
+      property="og:url"
+      content="https://www.eventregistrationtool.com/"
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Event Registration Tool"
+    />
+    <meta
+      property="og:image"
+      content="https://eventregistrationtool.com/assets/favicon.ico"
+    />
+    <meta
+      name="og:description"
+      content="The Event Registration Tool provides everything you need when it comes to event registration and management."
+    />
+    <meta
+      name="fb:app_id"
+      content="217890171695297"
+    />
     <base href="/" />
 
     <title


### PR DESCRIPTION
I noticed there was some warnings in the admin menu on Facebook developers saying we should add these. So I went ahead and did so.
<img width="1001" alt="Screen Shot 2020-12-02 at 3 15 03 PM" src="https://user-images.githubusercontent.com/39680460/100926725-e1f94e80-34b1-11eb-92f6-7af0199ce43a.png">
