### PR TITLE
Fix-uib-popover-trigger

### DIFF
--- a/app/views/components/blockEditor.html
+++ b/app/views/components/blockEditor.html
@@ -128,7 +128,7 @@
           <label class="inline-label" translate>Title</label>
           <i
             uib-popover-template="popup.titleTemplateUrl"
-            popover-trigger="mouseenter"
+            popover-trigger="'mouseenter'"
             popover-placement="right"
             class="fa fa-question-circle question-popover"
           >
@@ -148,7 +148,7 @@
           <label class="inline-label" translate>Description</label>
           <i
             uib-popover-template="popup.titleTemplateUrl"
-            popover-trigger="mouseenter"
+            popover-trigger="'mouseenter'"
             popover-placement="right"
             class="fa fa-question-circle question-popover"
           >
@@ -274,7 +274,7 @@
           <label class="inline-label" translate>Export Title</label>
           <i
             uib-popover="Enter a value here to replace the question title in a registration export."
-            popover-trigger="mouseenter"
+            popover-trigger="'mouseenter'"
             class="fa fa-question-circle question-popover"
           ></i>
           <input
@@ -354,7 +354,7 @@
               </label>
               <i
                 uib-popover="{{'This question will be visible to admins only and will not be seen by registrants. This can be used for bookkeeping meta information like room assignments.' | translate}}"
-                popover-trigger="mouseenter"
+                popover-trigger="'mouseenter'"
                 class="fa fa-question-circle question-popover"
               ></i>
             </div>

--- a/app/views/eventDetails/eventInformation.html
+++ b/app/views/eventDetails/eventInformation.html
@@ -11,7 +11,7 @@
       uib-popover="{{'10 character or less abbreviation of Event Name.  This will be used as the first part of the
         Description on the Staff Account Transfers upload report and Cash & Check Deposit report.  Including an abbreviation will help those who pay by
          transfer know which event the transfer is paying for when they view their staff account expense report.' | translate}}"
-      popover-trigger="mouseenter"
+      popover-trigger="'mouseenter'"
       popover-append-to-body="true"
     >
     </i>

--- a/app/views/eventDetails/paymentOptions.html
+++ b/app/views/eventDetails/paymentOptions.html
@@ -175,7 +175,7 @@
         <i
           class="question-popover fa fa-question-circle"
           uib-popover="{{'Changing the currency symbol only affects the display on the registration pages. The amounts recorded do not have the currency symbol included, therefore the event administrators extracting the data need to know what currency was used. Only one currency can be selected per event and it’s not recommend changing this once people have begun to register.' | translate}}"
-          popover-trigger="mouseenter"
+          popover-trigger="'mouseenter'"
           popover-append-to-body="true"
         >
         </i>

--- a/app/views/eventDetails/promotions.html
+++ b/app/views/eventDetails/promotions.html
@@ -124,7 +124,7 @@
               <i
                 class="question-popover fa fa-question-circle"
                 uib-popover="{{'Applies discount to all registrants in the registration, if applicable. If unchecked, discount will only be applied once per registration.' | translate}}"
-                popover-trigger="mouseenter"
+                popover-trigger="'mouseenter'"
                 popover-append-to-body="true"
               >
               </i>

--- a/app/views/eventDetails/regOptions.html
+++ b/app/views/eventDetails/regOptions.html
@@ -121,7 +121,7 @@
       <i
         class="question-popover fa fa-question-circle"
         uib-popover="{{'Requiring users to login gives them the option to come back at a later time and finish making payments (if applicable) and/or modify their registration (if enabled below).' | translate}}"
-        popover-trigger="mouseenter"
+        popover-trigger="'mouseenter'"
         popover-append-to-body="true"
       >
       </i>
@@ -156,7 +156,7 @@
       <i
         class="question-popover fa fa-question-circle"
         uib-popover="{{'This includes editing answers and adding group members.' | translate}}"
-        popover-trigger="mouseenter"
+        popover-trigger="'mouseenter'"
         popover-append-to-body="true"
       >
       </i>
@@ -173,7 +173,7 @@
       <i
         class="question-popover fa fa-question-circle"
         uib-popover="{{'Combining spouse registrations will force a husband and wife to be on the same group registration instead of on two separate registrations. Note that the first spouse must register as a registrant type that allows group members for this option to have any effect.' | translate}}"
-        popover-trigger="mouseenter"
+        popover-trigger="'mouseenter'"
         popover-append-to-body="true"
       >
       </i>
@@ -187,7 +187,7 @@
     <i
       class="question-popover fa fa-question-circle"
       uib-popover="{{'Allows for custom styling of the registration pages. This CSS file will be applied to the registration pages for your conference. It has no effect on the admin pages or home page. Must be hosted at an https:// url and have a .css file extension.' | translate}}"
-      popover-trigger="mouseenter"
+      popover-trigger="'mouseenter'"
       popover-append-to-body="true"
     >
     </i>
@@ -228,7 +228,7 @@
     Image<i
       class="question-popover fa fa-question-circle header-tooltip"
       uib-popover="{{'Allows for adding an image to either just the Registration landing page or also each of the individual Registration pages. Note that the image must first be saved before it can be previewed in a Registration Form.' | translate}}"
-      popover-trigger="mouseenter"
+      popover-trigger="'mouseenter'"
       popover-append-to-body="true"
     ></i>
   </h2>

--- a/app/views/eventDetails/regTypes.html
+++ b/app/views/eventDetails/regTypes.html
@@ -88,7 +88,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'Hiding this type from the public registration form will require the participant to have a direct link in order to register. These links can be found on the Event Overview page.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   popover-append-to-body="true"
                 >
                 </i>
@@ -119,7 +119,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'When selected, the user will not be given the option to add more people to the registration. One person per registration.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   popover-append-to-body="true"
                 >
                 </i>
@@ -137,7 +137,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'When selected, the user will be permitted to add more registrants (e.g. a spouse, child, student) to the registration.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   popover-append-to-body="true"
                 >
                 </i>
@@ -155,7 +155,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'When selected, this type will not become available until at least one registrant which has \'Group Registration\' set to \'Yes - Primary\' has been added to the registration.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   popover-append-to-body="true"
                 >
                 </i>
@@ -167,7 +167,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'Select which registrant types are allowed to be associated with this registrant group, and specify the maximum number of registrants allowed to use that type. Note that the default behavior when not selecting ANY associated registrant types will result in showing ALL registrant types on the group registration page.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   popover-append-to-body="true"
                 >
                 </i>
@@ -216,7 +216,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'Users will be redirected to the page below upon completion of their registration.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   popover-append-to-body="true"
                 >
                 </i>
@@ -235,7 +235,7 @@
                 <i
                   class="warning-popover fa fa-exclamation-triangle"
                   uib-popover="{{'Since this is a Cru Event, you must enter a Chartfield under the Payments Options tab to enable payments.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   ng-if="cruEventWithoutChartfield()"
                 >
                 </i>
@@ -252,7 +252,7 @@
                 <i
                   class="warning-popover fa fa-exclamation-triangle"
                   uib-popover="{{'Enter credit card processing details under the Payment Options tab to enable this option.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                   ng-if="!conference.paymentGatewayId"
                 >
                 </i>
@@ -300,7 +300,7 @@
                 <i
                   class="question-popover fa fa-question-circle"
                   uib-popover="{{'No payment will be required at time of registration, but will display the total due.' | translate}}"
-                  popover-trigger="mouseenter"
+                  popover-trigger="'mouseenter'"
                 >
                 </i>
               </div>
@@ -422,7 +422,7 @@
               <i
                 class="question-popover fa fa-question-circle"
                 uib-popover="{{'Your event name, start time and end time will be included in the email by default' | translate}}"
-                popover-trigger="mouseenter"
+                popover-trigger="'mouseenter'"
               >
               </i>
               <button

--- a/app/views/eventRegistrations.html
+++ b/app/views/eventRegistrations.html
@@ -405,7 +405,7 @@
                 class="fa fa-question-circle"
                 button
                 uib-popover-template="paidPopoverTemplateUrl"
-                popover-trigger="mouseenter"
+                popover-trigger="'mouseenter'"
                 popover-append-to-body="true"
               >
               </i>

--- a/app/views/modals/choiceOptions.html
+++ b/app/views/modals/choiceOptions.html
@@ -18,7 +18,7 @@
     <label translate>Export Value</label>
     <i
       uib-popover="{{'Enter a value here to replace the answer in a registration export.' | translate}}"
-      popover-trigger="mouseenter"
+      popover-trigger="'mouseenter'"
       class="fa fa-question-circle question-popover"
     ></i>
     <input


### PR DESCRIPTION
A small bug I noticed while working on the new journal upload page and adding a popover there. Checked the [docs](https://angular-ui.github.io/bootstrap/) to confirm the correct value. The popover technically still worked, the user just had to click on it instead of hovering over it. Not sure if it used to be ```mouseenter``` and there was a change along the way or something.