### PR TITLE
update-submitAccountTransfers-error-message

### DIFF
--- a/app/scripts/services/journalUploadService.js
+++ b/app/scripts/services/journalUploadService.js
@@ -2,6 +2,7 @@ angular
   .module('confRegistrationWebApp')
   .service('journalUploadService', function JournalUploadService(
     $rootScope,
+    $route,
     $http,
     $q,
     modalMessage,
@@ -122,8 +123,9 @@ angular
             message:
               errorResponse.data && errorResponse.data.error
                 ? errorResponse.data.error
-                : 'An error occurred while attempting to submit account transfers.',
+                : 'Journal Upload process time varies by the size of the list submitted and your submission is taking longer than expected to process, check back on the Journal Upload page in few moments for your report for this submission. (Please DO NOT submit the same transactions again while waiting or charges will be duplicated).',
           });
+          $route.reload();
         });
     };
   });

--- a/app/scripts/services/journalUploadService.js
+++ b/app/scripts/services/journalUploadService.js
@@ -119,11 +119,18 @@ angular
         .catch(errorResponse => {
           $rootScope.loadingMsg = '';
           modalMessage.error({
-            title: 'Error Submitting Account Transfers',
+            title:
+              errorResponse.data && errorResponse.data.error
+                ? 'Error Submitting Account Transfers'
+                : 'Journal Upload Delay',
             message:
               errorResponse.data && errorResponse.data.error
                 ? errorResponse.data.error
-                : 'Journal Upload process time varies by the size of the list submitted and your submission is taking longer than expected to process, check back on the Journal Upload page in few moments for your report for this submission. (Please DO NOT submit the same transactions again while waiting or charges will be duplicated).',
+                : '<p>Journal Upload process time varies by the size of the list submitted and your submission is taking longer than expected to process. The system is still working to complete your request.</p>' +
+                  '<br>' +
+                  '<p>The transactions submitted in this Journal will still be listed on the "New Report" transactions list until this submission is complete. Please DO NOT submit the same transactions again while waiting or charges will be duplicated.</p>' +
+                  '<br>' +
+                  '<p>Check back in a few minutes to see if your submitted report is in the dropdown box beside "Report Creation Date." Once your submitted report shows up in the dropdown box all completed transactions will no longer be listed in the "New Report" transactions list.</p>',
           });
           $route.reload();
         });


### PR DESCRIPTION
Basically, the journal upload submission is taking a long time to process, depending on the number of account transfers included. This is causing a gateway timeout issue. A temporary fix, until API optimization can be done, is to just update the error message for the users to make sure they don't accidentally resubmit. 