### PR TITLE
Update-Create-Okta-Account-Text

### DIFF
--- a/app/views/modals/loginDialog.html
+++ b/app/views/modals/loginDialog.html
@@ -36,12 +36,15 @@
         >
         <a href="oktaDescription/" target="_blank" translate>What is Okta?</a>
         <br />
-        <a
-          href="https://signon.cru.org/cas/login?action=signup&service=https%3A%2F%2Fapi.eventregistrationtool.com%2Feventhub-api%2Frest%2Fauth%2Frelay%2Flogin%3FlogoutCallbackUrl%3Dhttps%3A%2F%2Fapi.eventregistrationtool.com%2Feventhub-api%2Frest%2Fauth%2Frelay%2Flogout"
-          target="_blank"
-          translate
-          >Create an Okta account</a
-        >
+        <p translate>
+          Don't have an Okta account?
+        </p>
+        <p translate>
+          Click the
+          <strong>Okta</strong>
+          button above, then
+          <strong>Sign up</strong>.
+        </p>
       </div>
     </div>
     <p class="spacing-above-sm">


### PR DESCRIPTION
This PR adds a temporary workaround to the current issue we are running into regarding linking to new user registration for an Okta account and then redirecting back to the app. This solution is based on the one implemented in https://github.com/CruGlobal/mpdx_web/pull/2233/commits/5d3d763b4f7eb5de9354b05b39ace1943a896499. The true solution probably lies on the API side in this case, or will eventually. But the docs do not provide much in terms of a solution for this issue at the moment(from what I've been able to find so far). 