### PR TITLE
Fix-Duplicate-Credit-Card-Transaction-Issue

### DIFF
--- a/app/scripts/controllers/reviewRegistration.js
+++ b/app/scripts/controllers/reviewRegistration.js
@@ -170,8 +170,6 @@ angular
           });
 
           $scope.navigateToPostRegistrationPage();
-
-          $scope.submittingRegistration = false;
         })
         .catch(function(response) {
           handleRegistrationError((response && response.data) || response);

--- a/app/views/reviewRegistration.html
+++ b/app/views/reviewRegistration.html
@@ -415,13 +415,15 @@
       <p ng-if="!allRegistrantsValid()" style="color:red;" translate>
         Please fill in all required fields in red before submitting.
       </p>
-      <input
-        type="button"
+      <button
         class="btn btn-lg btn-success btn-important confirm-registration"
         ng-click="confirmRegistration()"
-        value="Confirm"
         ng-disabled="registerDisabled()"
-      />
+      >
+        <translate ng-if="!submittingRegistration">Confirm</translate>
+        <translate ng-if="submittingRegistration">Submitting...</translate>
+        <i ng-if="submittingRegistration" class="fa fa-spinner fa-spin"></i>
+      </button>
       <span ng-show="registerMode === 'preview'"
         >&laquo; <translate>Disabled in preview mode</translate></span
       >


### PR DESCRIPTION
So with the addition of DocuSign, it has extended the confirmation time when submitting a registration. We believe that this extended wait time, along with no indicator of anything happening has made users impatient while they wait for the registration to submit. Possibly causing them to spam click the confirm button. Lee discovered that there's a small window between once the registration is complete and when the user is navigated to the confirmation page that the confirm button becomes enabled again and the user can press it. This will create a duplicate credit card transaction if pressed, causing the user to be charged twice. Lee and I both reproduced this on staging several times with ease. The solution was to leave the button disabled(unless there's an error with submitting), as they will be redirected to a different page. I also went ahead and added new text and a loading indicator to better reflect the submitting state.