### PR TITLE
Fix-Registration-Error-Messages-From-API

### DIFF
--- a/app/scripts/services/registration.js
+++ b/app/scripts/services/registration.js
@@ -46,7 +46,7 @@ angular
             },
             function(response) {
               currentRegistration.completed = false;
-              reject(response.data);
+              reject(response);
             },
           );
         }).catch(


### PR DESCRIPTION
@Benjamin-deVries Made a change to the API to return a specific error message when a user is registering and submits an invalid email. However, the frontend was not displaying this message and instead was using the default message set here: https://github.com/CruGlobal/conf-registration-web/blob/2bcc18f26066c2110ef99d5371411a54fb6ee023/app/scripts/services/registration.js#L52-L54

This change makes sure that the correlated logic for displaying error messages looks at the correct response object that is expected. https://github.com/CruGlobal/conf-registration-web/blob/2bcc18f26066c2110ef99d5371411a54fb6ee023/app/scripts/services/error.js#L9

I think there's a deeper issue here though that I will need to investigate and fix in a separate pr. We are noticing an increase in invalid emails and I believe it's because the frontend doesn't prevent continuing to the next page if there is an invalid email. It displays the error under the input but doesn't prevent action.
<img width="660" alt="Screen Shot 2021-11-29 at 1 43 21 PM" src="https://user-images.githubusercontent.com/39680460/143926286-d5bb8844-46b7-4de2-8ef2-2575a93436c4.png">