### PR TITLE
Update-Email-Regex

### DIFF
--- a/app/scripts/services/validateRegistrant.js
+++ b/app/scripts/services/validateRegistrant.js
@@ -285,7 +285,16 @@ angular
             }
             break;
           case 'emailQuestion':
-            if (_.isEmpty(answer) || _.isNull(answer.match(/^.+@.+$/))) {
+            if (
+              _.isEmpty(answer) ||
+              _.isNull(
+                answer.match(
+                  // pulled from https://github.com/jquense/yup/blob/acbb8b4f3c24ceaf65eab09abaf8e086a9f11a73/src/string.ts#L9
+                  // eslint-disable-next-line no-control-regex
+                  /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/,
+                ),
+              )
+            ) {
               //Contains an @ sign surrounded by at least one character
               invalidBlocks.push(block.id);
               return;


### PR DESCRIPTION
This is related to the comment I made in https://github.com/CruGlobal/conf-registration-web/pull/768. It looks like this regex pattern allowed a lot of invalid emails to slip through. So I updated to this one that uses a more strict email regex pattern. 

I'm also considering using the regex pattern that ```yup``` uses for validating emails: https://github.com/jquense/yup/blob/acbb8b4f3c24ceaf65eab09abaf8e086a9f11a73/src/string.ts#L9