### PR TITLE
EVENT-785-First-Page-Visible-When-No-Content-Applies

### DIFF
--- a/app/scripts/directives/registrationTypeSelect.js
+++ b/app/scripts/directives/registrationTypeSelect.js
@@ -96,6 +96,13 @@ angular
 
         $scope.newRegistrant = function(type) {
           var newId = uuid();
+          // Filter through all pages and remove any empty pages
+          const validPages = $scope.conference.registrationPages.filter(
+            page =>
+              page.blocks.filter(block => !block.registrantTypes.includes(type))
+                .length > 0,
+          );
+
           $scope.currentRegistration.registrants.push({
             id: newId,
             registrationId: $scope.currentRegistration.id,
@@ -113,7 +120,7 @@ angular
                     '/' +
                     $scope.conference.id +
                     '/page/' +
-                    $scope.conference.registrationPages[0].id,
+                    validPages[0].id,
                 )
                 .search('reg', newId);
             },

--- a/app/views/registration.html
+++ b/app/views/registration.html
@@ -165,7 +165,7 @@
         <div class="col-sm-9 col-xs-6">
           <a
             ng-href="{{ registerMode }}/{{ conference.id }}/page/{{
-              conference.registrationPages[0].id
+              validPages[0].id
             }}?reg={{ currentRegistration.registrants[0].id }}"
             class="btn btn-success btn-important btn-lg btn-block"
             translate
@@ -175,9 +175,6 @@
         </div>
       </div>
     </section>
-    <page
-      ng-repeat="page in conference.registrationPages"
-      ng-if="page.id == activePageId"
-    ></page>
+    <page ng-repeat="page in validPages" ng-if="page.id == activePageId"></page>
   </div>
 </div>


### PR DESCRIPTION
Ticket: https://jira.cru.org/browse/EVENT-785

Basically, two bugs were happening and this fix resolves them both. If the first page is empty, as in no questions, when the user started registering they would land on that first page and it would be empty. The second has a similar end result of an empty page, but was resulted because there were no questions on the first page for the specific ```registrantType```. The ticket shows this in more detail.

So my fix was to filter out all pages that have no questions blocks. This was happening in some capacity already, but the links navigated to the first page, regardless of if it had any valid question blocks or if it was ```visible```.