### PR TITLE
EVENT-786-Associated-Registration-Types-Disappear

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -537,9 +537,8 @@ angular
               $scope.originalConference = conference = angular.copy(
                 response.data,
               );
+              $scope.refreshAllowedRegistrantTypes();
             });
-
-            $scope.refreshAllowedRegistrantTypes();
 
             //Clear cache
             ConfCache.empty();


### PR DESCRIPTION
Ticket: https://jira.cru.org/browse/EVENT-786

Basically the ```refreshAllowedRegistrantTypes``` was happening before the GET, so then the ```$scope.conference``` was getting overridden by the ```response.data``` which isn't correctly formatted as needed.