### PR TITLE
EVENT-781-Improvement

### DIFF
--- a/app/views/eventOverview.html
+++ b/app/views/eventOverview.html
@@ -24,7 +24,7 @@
           <h2 class="page-title border" translate>Event Information</h2>
           <p><strong>{{conference.name}}</strong></p>
           <p
-            ng-bind-html="conference.description | toTrustedHtml"
+            ng-bind-html="conference.description"
             ng-show="conference.description"
             class="display-linebreaks"
           ></p>

--- a/app/views/landing.html
+++ b/app/views/landing.html
@@ -107,7 +107,7 @@
         </p>
         <p
           class="spacing-above-md display-linebreaks"
-          ng-bind-html="e.description | toTrustedHtml"
+          ng-bind-html="e.description"
           ng-show="e.description"
         ></p>
         <div class="text-center">

--- a/app/views/modals/accessEvent.html
+++ b/app/views/modals/accessEvent.html
@@ -39,10 +39,7 @@
     </div>
     <p><strong>{{selectedEvent.name}}</strong></p>
     <br />
-    <p
-      class="display-linebreaks"
-      ng-bind-html="selectedEvent.description | toTrustedHtml"
-    ></p>
+    <p class="display-linebreaks" ng-bind-html="selectedEvent.description"></p>
     <p>
       <strong translate>Dates:</strong> {{selectedEvent.eventStartTime |
       evtDateFormat: selectedEvent.eventTimezone}} -

--- a/app/views/registration.html
+++ b/app/views/registration.html
@@ -86,10 +86,7 @@
     </div>
     <section ng-if="activePageId == ''">
       <h2 class="page-title border" translate>Welcome</h2>
-      <p
-        ng-bind-html="conference.description | toTrustedHtml"
-        class="display-linebreaks"
-      ></p>
+      <p ng-bind-html="conference.description" class="display-linebreaks"></p>
       <div class="well well-creme2" ng-show="conference.eventStartTime">
         <h2 class="page-title border details-heading" translate>Event Dates</h2>
         <p>

--- a/app/views/reviewRegistration.html
+++ b/app/views/reviewRegistration.html
@@ -28,10 +28,7 @@
         <h2 class="page-title border" class="page-title border details-heading">
           {{conference.name}}
         </h2>
-        <p
-          ng-bind-html="conference.description | toTrustedHtml"
-          class="display-linebreaks"
-        ></p>
+        <p ng-bind-html="conference.description" class="display-linebreaks"></p>
 
         <strong translate>Event Dates</strong>
         <p>


### PR DESCRIPTION
After talking with some of the people from the ERT team, I recommended it would be better for safety reasons to not use ```toTrustedHTML```. They do lose the ability to use CSS, but the security benefits we gain outway that utility I believe.

Security reasons behind this are the fact that ```$sce.trustAsHtml``` overrides the ```ngSanitize``` that should normally happen. This means whatever is inputted, is not checked for anything that could be 'unsafe'. The sanitize logic essentially strips out everything that is not basic HTML code, including css, scripts, etc. 

With overriding the sanitize logic, I can do the following:
<img width="923" alt="Screen Shot 2022-01-31 at 10 24 37 AM" src="https://user-images.githubusercontent.com/39680460/151821271-52ee99ba-8e77-4e30-89b8-8031e70a3db5.png">
and since it's not scrubbed out, it gets executed
<img width="587" alt="Screen Shot 2022-01-31 at 10 24 46 AM" src="https://user-images.githubusercontent.com/39680460/151821332-feab10eb-e45d-47f6-9b2a-9dffd2dae617.png">
