### PR TITLE
Fix-Skip-Next-Page-Bug

### DIFF
--- a/app/scripts/controllers/registration.js
+++ b/app/scripts/controllers/registration.js
@@ -62,11 +62,33 @@ angular
             })
           : $scope.conference.registrationPages;
 
+      $scope.checkValidPages = () => {
+        $scope.validPages = $scope.conference.registrationPages.filter(
+          (page) => {
+            const registrantId = $scope.currentRegistrant
+              ? $scope.currentRegistrant
+              : $scope.currentRegistration.registrants[0].id;
+
+            return (
+              page.blocks.filter((block) =>
+                validateRegistrant.blockVisible(
+                  block,
+                  currentRegistration.registrants.find(
+                    (r) => r.id === registrantId,
+                  ),
+                ),
+              ).length > 0
+            );
+          },
+        );
+      };
+
       $scope.page = _.find($scope.validPages, { id: pageId });
       $scope.activePageIndex = _.findIndex($scope.validPages, {
         id: pageId,
       });
       $scope.nextPage = function () {
+        $scope.checkValidPages();
         var visiblePageArray = _.filter($scope.validPages, function (page) {
           return $scope.pageIsVisible(page);
         });

--- a/test/spec/controllers/registration.spec.js
+++ b/test/spec/controllers/registration.spec.js
@@ -113,7 +113,11 @@ describe('Controller: registration', () => {
 
     expect(currentPage).toEqual(scope.conference.registrationPages[0]);
 
+    const checkValidPagesSpy = spyOn(scope, 'checkValidPages');
+
     const nextPage = scope.nextPage();
+
+    expect(checkValidPagesSpy).toHaveBeenCalledWith();
 
     expect(scope.validPages.length).toEqual(2);
 

--- a/test/spec/controllers/registration.spec.js
+++ b/test/spec/controllers/registration.spec.js
@@ -107,4 +107,16 @@ describe('Controller: registration', () => {
 
     expect(scope.validPages.length).toEqual(1);
   });
+
+  it('should run nextPage', () => {
+    const currentPage = scope.page;
+
+    expect(currentPage).toEqual(scope.conference.registrationPages[0]);
+
+    const nextPage = scope.nextPage();
+
+    expect(scope.validPages.length).toEqual(2);
+
+    expect(nextPage).toEqual(scope.conference.registrationPages[1]);
+  });
 });

--- a/test/spec/controllers/registration.spec.js
+++ b/test/spec/controllers/registration.spec.js
@@ -1,0 +1,110 @@
+import angular from 'angular';
+import 'angular-mocks';
+
+describe('Controller: registration', () => {
+  let scope, testData;
+
+  beforeEach(angular.mock.module('confRegistrationWebApp'));
+
+  beforeEach(
+    angular.mock.inject(
+      (
+        $rootScope,
+        $controller,
+        $routeParams,
+        _testData_,
+        _validateRegistrant_,
+      ) => {
+        testData = _testData_;
+        scope = $rootScope.$new();
+        scope.conference = testData.conference;
+        scope.currentRegistration = testData.registration;
+        angular.extend($routeParams, {
+          reg: testData.registration.registrants[0].id,
+          pageId: testData.conference.registrationPages[0].id,
+        });
+
+        $controller('RegistrationCtrl', {
+          $rootScope,
+          $scope: scope,
+          conference: testData.conference,
+          currentRegistration: testData.registration,
+          $routeParams,
+          validateRegistrant: _validateRegistrant_,
+        });
+      },
+    ),
+  );
+
+  it('should have validPages based on current registrant', () => {
+    let validPages = scope.validPages;
+
+    expect(validPages.length).toEqual(2);
+  });
+
+  it('should getFirstValidPage', () => {
+    let currentRegistrant = scope.currentRegistrant;
+
+    expect(currentRegistrant).toEqual(testData.registration.registrants[0].id);
+    let validFirstPage = scope.getValidFirstPage(currentRegistrant);
+
+    expect(validFirstPage).toEqual(scope.conference.registrationPages[0]);
+  });
+
+  it('should run checkValidPages and update validPages', () => {
+    scope.conference.registrationPages = [
+      {
+        id: '5c69bfcc-9e35-4bd8-8358-fe50fd86052d',
+        conferenceId: 'c63b8abf-52ff-4cc4-afbc-5923b01f1ab0',
+        title: 'Some number questions',
+        position: 0,
+        blocks: [
+          {
+            id: 'e088fefc-eb9c-4904-b849-017facc9e063',
+            pageId: '5c69bfcc-9e35-4bd8-8358-fe50fd86052d',
+            title: 'Number',
+            exportFieldTitle: null,
+            type: 'numberQuestion',
+            required: true,
+            position: 0,
+            content: null,
+            profileType: null,
+            registrantTypes: [],
+            rules: [],
+          },
+        ],
+      },
+      {
+        id: '5c69bfcc-9e35-4bd8-8358-fe50fd86052d',
+        conferenceId: 'c63b8abf-52ff-4cc4-afbc-5923b01f1ab0',
+        title: 'Some more number questions',
+        position: 0,
+        blocks: [
+          {
+            id: 'e088fefc-eb9c-4904-b849-017facc9e063',
+            pageId: '5c69bfcc-9e35-4bd8-8358-fe50fd86052d',
+            title: 'Other number question',
+            exportFieldTitle: null,
+            type: 'numberQuestion',
+            required: false,
+            position: 0,
+            content: null,
+            profileType: null,
+            registrantTypes: ['47de2c40-19dc-45b3-9663-5c005bd6464b'],
+            rules: [],
+          },
+        ],
+      },
+    ];
+
+    expect(scope.validPages.length).toEqual(2);
+    scope.currentRegistrant = testData.registration.registrants[1].id;
+    scope.checkValidPages();
+
+    expect(scope.currentRegistrant).toEqual(
+      scope.currentRegistration.registrants[1].id,
+    );
+
+    expect(scope.validPages.length).toEqual(1);
+  });
+});


### PR DESCRIPTION
Interesting bug, basically a page now only renders if it has valid questions based on registrant type after my rework. But the question and answer rules also affect this. If an answer to a question causes another question to be visible on another page and the page wasn't valid before, AND that page is the next page, it basically would be skipped if you pressed 'Next Page'. But now we are continually checking valid pages as they navigate to the next page. I don't think this is needed for navigating back as rules shouldn't apply to previous pages.