### PR TITLE
HS-757382 - Fix typo

### DIFF
--- a/app/scripts/components/ExportModal/ExportModal.tsx
+++ b/app/scripts/components/ExportModal/ExportModal.tsx
@@ -44,7 +44,7 @@ const ExportModal = ({
 
   const handleClose = () => modalInstance.dismiss();
 
-  let exportParameters = `Authorization=${authToken}&includedWithdrawn=${
+  let exportParameters = `Authorization=${authToken}&includeWithdrawn=${
     includeWithdrawnRegistrants ? 'yes' : 'no'
   }&includeIncomplete=${includeIncompleteRegistrations ? 'yes' : 'no'}`;
   const filterString = `&applyUiFilters=true&filter=${encodeURIComponent(


### PR DESCRIPTION
The endpoint accepts `includeWithdrawn` not `includedWithdrawn` as a query parameter.

[Helpscout ticket](https://secure.helpscout.net/conversation/1872200440/757382)