### PR TITLE
HS-768912 - Only set includeWithdrawn and includeIncomplete once

### DIFF
--- a/app/scripts/components/ExportModal/ExportModal.tsx
+++ b/app/scripts/components/ExportModal/ExportModal.tsx
@@ -44,21 +44,24 @@ const ExportModal = ({
 
   const handleClose = () => modalInstance.dismiss();
 
-  let exportParameters = `Authorization=${authToken}&includeWithdrawn=${
-    includeWithdrawnRegistrants ? 'yes' : 'no'
-  }&includeIncomplete=${includeIncompleteRegistrations ? 'yes' : 'no'}`;
+  let includeWithdrawn = includeWithdrawnRegistrants ? 'yes' : 'no';
+  let includeIncomplete = includeIncompleteRegistrations ? 'yes' : 'no';
+
+  let exportParameters = `Authorization=${authToken}`;
   const filterString = `&applyUiFilters=true&filter=${encodeURIComponent(
     queryParameters.filter,
   )}&filterPayment=${queryParameters.filterPayment}&filterRegType=${
     queryParameters.filterRegType
   }&includeCheckedin=${queryParameters.includeCheckedin}&includeEFormStatus=${
     queryParameters.includeEFormStatus
-  }&includeIncomplete=${queryParameters.includeIncomplete}&includeWithdrawn=${
-    queryParameters.includeWithdrawn
   }&order=${queryParameters.order}&orderBy=${queryParameters.orderBy}`;
   if (includeFilters) {
+    includeWithdrawn = queryParameters.includeWithdrawn;
+    includeIncomplete = queryParameters.includeIncomplete;
     exportParameters += filterString;
   }
+  exportParameters += `&includeWithdrawn=${includeWithdrawn}`;
+  exportParameters += `&includeIncomplete=${includeIncomplete}`;
   angular.forEach(queryParameters.block, (blockId) => {
     exportParameters += `&block=${blockId}`;
   });


### PR DESCRIPTION
[Helpscout](https://secure.helpscout.net/conversation/1899342115/768912/)

When we fixed an issue in #807 to use the correct query parameters, we caused a new issue where we send the correct query parameters twice in the case of a filter being applied. Instead of overriding the `includeWithdrawn` and `includeIncomplete`, we were using both values: the ones from the checkboxes on the modal and the ones from the applied filtering.

This PR uses one value for each based on whether or not the filtering is applied.