### PR TITLE
Debounce option changes

### DIFF
--- a/app/views/blocks/radioQuestion.html
+++ b/app/views/blocks/radioQuestion.html
@@ -16,7 +16,6 @@
       name="{{ block.id }}"
       ng-required="block.required"
       ng-model="$parent.selectedAnswer"
-      ng-model-options="{ debounce: 1000 }"
       ng-value="choice.value"
     />
     <strong>{{ choice.value }}</strong>
@@ -48,7 +47,6 @@
     name="{{ block.id }}"
     ng-required="block.required"
     ng-model="selectedAnswer"
-    ng-model-options="{ debounce: 1000 }"
     ng-value="otherSentinel"
   />
   <input
@@ -56,7 +54,6 @@
     class="form-control"
     show-errors
     ng-model="otherAnswer"
-    ng-model-options="{ debounce: 1000 }"
     ng-change="selectOtherAnswer()"
     ng-required="selectedAnswer === otherSentinel"
     style="display: inline; width: auto"

--- a/test/spec/directives/block.spec.js
+++ b/test/spec/directives/block.spec.js
@@ -5,10 +5,17 @@ describe('Directive: blocks', () => {
   beforeEach(angular.mock.module('confRegistrationWebApp'));
 
   describe('radioQuestion', () => {
-    let $compile, $rootScope, $scope;
-    beforeEach(inject((_$compile_, _$rootScope_, $templateCache, testData) => {
+    let $compile, $rootScope, $scope, $timeout;
+    beforeEach(inject((
+      _$compile_,
+      _$rootScope_,
+      _$timeout_,
+      $templateCache,
+      testData,
+    ) => {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
+      $timeout = _$timeout_;
 
       $scope = $rootScope.$new();
       $templateCache.put('views/blocks/radioQuestion.html', '');
@@ -80,13 +87,13 @@ describe('Directive: blocks', () => {
       expect($scope.answer.value).toBe('');
 
       $scope.selectedAnswer = 'Option 1';
-      $scope.$digest();
+      $timeout.flush();
 
       expect($scope.answer.value).toBe('Option 1');
 
       $scope.selectedAnswer = '__other__';
       $scope.otherAnswer = 'Other';
-      $scope.$digest();
+      $timeout.flush();
 
       expect($scope.answer.value).toBe('Other');
     });
@@ -116,6 +123,38 @@ describe('Directive: blocks', () => {
       $scope.clearAnswer();
 
       expect($scope.selectedAnswer).toBe('');
+    });
+
+    it('debounces answer updates', () => {
+      $scope.answer = { value: '' };
+      $compile('<radio-question></radio-question>')($scope);
+      $scope.$digest();
+
+      expect($scope.answer.value).toBe('');
+
+      $scope.selectedAnswer = 'Option 1';
+      $scope.$digest();
+
+      expect($scope.answer.value).toBe('');
+
+      $scope.selectedAnswer = 'Option 2';
+      $scope.$digest();
+
+      expect($scope.answer.value).toBe('');
+
+      $scope.otherAnswer = 'Other';
+      $scope.selectOtherAnswer();
+
+      expect($scope.answer.value).toBe('');
+
+      $scope.selectedAnswer = 'Option 1';
+      $scope.$digest();
+
+      expect($scope.answer.value).toBe('');
+
+      $timeout.flush();
+
+      expect($scope.answer.value).toBe('Option 1');
     });
   });
 });


### PR DESCRIPTION
For some reason, `ng-model-options="{ debounce: 1000 }"` doesn't play nicely with radio buttons. If you click one option then a different one within one second, the selection is cleared when the debounce finally updates the value, even though the modal value is still set. Someone had a similar issue [here](https://stackoverflow.com/questions/31254291/angularjs-debounce-is-clearing-my-radio-input) with no resolution besides using a different method for debouncing.

Work around this issue by manually performing the debouncing within the controller.