### PR TITLE
[no-Jira] Remove 100 item page option

### DIFF
--- a/app/scripts/components/RegistrationFilters/RegistrationFilters.test.tsx
+++ b/app/scripts/components/RegistrationFilters/RegistrationFilters.test.tsx
@@ -305,12 +305,12 @@ describe('RegistrationFilters component', () => {
       </RegistrationFilters>,
     );
 
-    await userEvent.click(getByRole('radio', { name: '100' }));
+    await userEvent.click(getByRole('radio', { name: '50' }));
 
     expect(onQueryChange).toHaveBeenCalledWith({
       filter: '',
       page: 1,
-      limit: 100,
+      limit: 50,
     });
   });
 });

--- a/app/scripts/components/RegistrationFilters/RegistrationFilters.tsx
+++ b/app/scripts/components/RegistrationFilters/RegistrationFilters.tsx
@@ -290,6 +290,7 @@ export const RegistrationFilters = (
             >
               <ToggleButton value={20}>20</ToggleButton>
               <ToggleButton value={50}>50</ToggleButton>
+              {/* TODO: Add back the 100 option once the API can handle submitting 100 registrations without timing out */}
               <ToggleButton value={0} disabled>
                 per page
               </ToggleButton>

--- a/app/scripts/components/RegistrationFilters/RegistrationFilters.tsx
+++ b/app/scripts/components/RegistrationFilters/RegistrationFilters.tsx
@@ -290,7 +290,6 @@ export const RegistrationFilters = (
             >
               <ToggleButton value={20}>20</ToggleButton>
               <ToggleButton value={50}>50</ToggleButton>
-              <ToggleButton value={100}>100</ToggleButton>
               <ToggleButton value={0} disabled>
                 per page
               </ToggleButton>


### PR DESCRIPTION
We are occasionally running into timeouts when uploading 100 transactions. Temporarily prevent these errors by making 50 the most transactions that can be viewed at one time. This will be reverted in the future when we have time for a better solution, like implementing batching on the server.

https://secure.helpscout.net/conversation/2211009504/924915/

Tested in staging ✅