### PR TITLE
[HS-946275] Fix multiple Angular directives error

### DIFF
--- a/app/scripts/directives/showErrors.js
+++ b/app/scripts/directives/showErrors.js
@@ -2,9 +2,6 @@ angular.module('confRegistrationWebApp').directive('showErrors', function () {
   return {
     restrict: 'A',
     require: 'ngModel',
-    scope: {
-      showErrorsInstant: '<',
-    },
     link: function (scope, element, attrs, ngModelCtrl) {
       //Logic to handle groups of inputs in one block
       if (attrs.showErrors === 'group') {
@@ -20,7 +17,7 @@ angular.module('confRegistrationWebApp').directive('showErrors', function () {
             ngModelCtrl.$invalid &&
             (scope.currentPageVisited ||
               ngModelCtrl.$touched ||
-              !!scope.showErrorsInstant)
+              !!scope.$eval(attrs.showErrorsInstant))
           );
         },
         function (invalid) {
@@ -31,7 +28,7 @@ angular.module('confRegistrationWebApp').directive('showErrors', function () {
                 currentValue.$invalid &&
                 (scope.currentPageVisited ||
                   currentValue.$touched ||
-                  !!scope.showErrorsInstant)
+                  !!scope.$eval(attrs.showErrorsInstant))
               );
             });
             element.toggleClass('has-no-error', !invalid);


### PR DESCRIPTION
Fix `Multiple directives [pickADate, showErrors (module: confRegistrationWebApp)] asking for new/isolated scope on: <pick-a-date>` error introduced in 192aaa30cd1c95ca990c815cccb36c19f55c0ab7.

Solution: revert the `show-errors` directive back to no longer creating a new isolated scope and instead using `$scope.$eval` to determine the value of the `show-errors-instant` attribute.

https://secure.helpscout.net/conversation/2245104032/946275?folderId=7599852