### PR TITLE
EVENT-821 Add Event Type dropdown menu

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -485,6 +485,18 @@ angular
           validationErrorsHint = eventInformationPageHint;
         }
 
+        if (
+          $scope.conference.cruEvent &&
+          $scope.conference.ministry &&
+          $scope.getEventTypes().length !== 0 &&
+          !$scope.conference.eventType
+        ) {
+          validationErrors.push(
+            'Please enter which Event Type is applicable for this event.*',
+          );
+          validationErrorsHint = eventInformationPageHint;
+        }
+
         if ($scope.conference.cruEvent && !$scope.conference.type) {
           validationErrors.push('Please enter Ministry Purpose.*');
           validationErrorsHint = eventInformationPageHint;
@@ -655,11 +667,27 @@ angular
         return currentMinistry ? currentMinistry.activities : [];
       };
 
+      $scope.getEventTypes = () => {
+        const currentMinistry =
+          $scope.ministries &&
+          $scope.ministries.find((m) => m.id === $scope.conference.ministry);
+        const currentPurpose =
+          $scope.ministryPurposes &&
+          $scope.ministryPurposes.find((p) => p.id === $scope.conference.type);
+        return $scope.eventTypes &&
+          (currentMinistry?.name?.includes('Campus') ||
+            currentPurpose?.name?.includes('Mission') ||
+            currentPurpose?.name?.includes('Conference'))
+          ? $scope.eventTypes
+          : [];
+      };
+
       $scope.$watch(
         'conference.ministry',
         function (newVal, oldVal) {
           if (newVal !== oldVal) {
             $scope.conference.strategy = null;
+            $scope.conference.eventType = null;
             $scope.conference.ministryActivity = null;
           }
         },
@@ -673,6 +701,7 @@ angular
             $scope.conference.ministry = null;
             $scope.conference.strategy = null;
             $scope.conference.type = null;
+            $scope.conference.eventType = null;
             $scope.conference.ministryActivity = null;
             $scope.conference.workProject = false;
           }
@@ -735,6 +764,13 @@ angular
       $http({
         method: 'GET',
         url: 'types',
+      }).then(function (response) {
+        $scope.ministryPurposes = response.data;
+      });
+
+      $http({
+        method: 'GET',
+        url: 'event/types',
       }).then(function (response) {
         $scope.eventTypes = response.data;
       });

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -108,14 +108,12 @@ angular
               });
               return {
                 id: existingChild ? existingChild.id : uuid(),
-                name: t.name,
+                //name: t.name,
                 childRegistrantTypeId: t.id,
                 numberOfChildRegistrants: existingChild
                   ? existingChild.numberOfChildRegistrants
                   : 0,
-                selected:
-                  existingChild !== undefined &&
-                  existingChild.selected !== false,
+                //selected: existingChild !== undefined && existingChild.selected !== false,
               };
             },
           );

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -675,9 +675,13 @@ angular
           $scope.ministryPurposes &&
           $scope.ministryPurposes.find((p) => p.id === $scope.conference.type);
         return $scope.eventTypes &&
-          (currentMinistry?.name?.includes('Campus') ||
-            currentPurpose?.name?.includes('Mission') ||
-            currentPurpose?.name?.includes('Conference'))
+          ((currentMinistry &&
+            currentMinistry.name &&
+            currentMinistry.name.includes('Campus')) ||
+            (currentPurpose &&
+              ((currentPurpose.name &&
+                currentPurpose.name.includes('Mission')) ||
+                currentPurpose.name.includes('Conference'))))
           ? $scope.eventTypes
           : [];
       };

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -480,7 +480,7 @@ angular
           !$scope.conference.ministryActivity
         ) {
           validationErrors.push(
-            'Please enter which Ministry Activitiy is applicable for this event.*',
+            'Please enter which Ministry Activity is applicable for this event.*',
           );
           validationErrorsHint = eventInformationPageHint;
         }
@@ -674,15 +674,11 @@ angular
         const currentPurpose =
           $scope.ministryPurposes &&
           $scope.ministryPurposes.find((m) => m.id === $scope.conference.type);
-        return $scope.eventTypes &&
-          ((currentMinistry &&
-            currentMinistry.name &&
-            currentMinistry.name.includes('Campus')) ||
-            (currentPurpose &&
-              ((currentPurpose.name &&
-                currentPurpose.name.includes('Mission')) ||
-                currentPurpose.name.includes('Conference'))))
-          ? $scope.eventTypes
+        return currentMinistry.eventTypes &&
+          currentPurpose &&
+          ((currentPurpose.name && currentPurpose.name.includes('Mission')) ||
+            currentPurpose.name.includes('Conference'))
+          ? currentMinistry.eventTypes
           : [];
       };
 
@@ -770,13 +766,6 @@ angular
         url: 'types',
       }).then(function (response) {
         $scope.ministryPurposes = response.data;
-      });
-
-      $http({
-        method: 'GET',
-        url: 'event/types',
-      }).then(function (response) {
-        $scope.eventTypes = response.data;
       });
 
       $scope.resetImage = () => {

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -108,12 +108,10 @@ angular
               });
               return {
                 id: existingChild ? existingChild.id : uuid(),
-                //name: t.name,
                 childRegistrantTypeId: t.id,
                 numberOfChildRegistrants: existingChild
                   ? existingChild.numberOfChildRegistrants
                   : 0,
-                //selected: existingChild !== undefined && existingChild.selected !== false,
               };
             },
           );

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -486,7 +486,7 @@ angular
         if (
           $scope.conference.cruEvent &&
           $scope.conference.ministry &&
-          $scope.getEventTypes().length !== 0 &&
+          $scope.getEventTypes().length &&
           !$scope.conference.eventType
         ) {
           validationErrors.push(
@@ -672,13 +672,24 @@ angular
         const currentPurpose =
           $scope.ministryPurposes &&
           $scope.ministryPurposes.find((m) => m.id === $scope.conference.type);
-        return currentMinistry.eventTypes &&
+        return currentMinistry &&
+          currentMinistry.eventTypes &&
           currentPurpose &&
           ((currentPurpose.name && currentPurpose.name.includes('Mission')) ||
             currentPurpose.name.includes('Conference'))
           ? currentMinistry.eventTypes
           : [];
       };
+
+      $scope.$watch(
+        'conference.type',
+        function (newVal, oldVal) {
+          if (newVal !== oldVal) {
+            $scope.conference.eventType = null;
+          }
+        },
+        true,
+      );
 
       $scope.$watch(
         'conference.ministry',

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -673,7 +673,7 @@ angular
           $scope.ministries.find((m) => m.id === $scope.conference.ministry);
         const currentPurpose =
           $scope.ministryPurposes &&
-          $scope.ministryPurposes.find((p) => p.id === $scope.conference.type);
+          $scope.ministryPurposes.find((m) => m.id === $scope.conference.type);
         return $scope.eventTypes &&
           ((currentMinistry &&
             currentMinistry.name &&

--- a/app/views/blocks/addressQuestion.html
+++ b/app/views/blocks/addressQuestion.html
@@ -64,7 +64,7 @@
       type="text"
       class="form-control"
       ng-model="answer.value.state"
-      ng-model-options="{ debounce: 1000 }"
+      ng-model-options="{ debounce: 300 }"
       ng-required="block.required && answer.value.country === 'US'"
       ng-disabled="editBlock"
       ng-if="currentRegions(answer.value.country).length <= 1"
@@ -93,7 +93,7 @@
       ng-model="answer.value.country"
       class="form-control"
       ng-required="block.required"
-      ng-model-options="{ debounce: 1000 }"
+      ng-model-options="{ debounce: 300 }"
       ng-disabled="editBlock"
     >
       <option ng-repeat="country in countries" ng-value="country[1]">

--- a/app/views/blocks/checkboxQuestion.html
+++ b/app/views/blocks/checkboxQuestion.html
@@ -20,7 +20,7 @@
         show-errors
         ng-required="block.required && !atLeastOneChecked()"
         ng-model="answer.value[choice.value]"
-        ng-model-options="{ debounce: 1000 }"
+        ng-model-options="{ debounce: 300 }"
         ng-disabled="block.content.forceSelections[choice.value] == true && (checkForceRule(block,'') || isAdmin)"
         ng-value="true"
       />
@@ -48,7 +48,7 @@
       <input
         type="checkbox"
         ng-model="block.content.forceSelections[choice.value]"
-        ng-model-options="{ debounce: 1000 }"
+        ng-model-options="{ debounce: 300 }"
         ng-value="true"
       />
       <strong translate>Force selection</strong>

--- a/app/views/blocks/genderQuestion.html
+++ b/app/views/blocks/genderQuestion.html
@@ -6,7 +6,7 @@
       name="{{ block.id }}"
       ng-required="block.required"
       ng-model="answer.value"
-      ng-model-options="{ debounce: 1000 }"
+      ng-model-options="{ debounce: 300 }"
       ng-value="choice.charAt(0)"
     />
     <strong>{{ choice }}</strong></label

--- a/app/views/blocks/nameQuestion.html
+++ b/app/views/blocks/nameQuestion.html
@@ -6,7 +6,7 @@
       class="form-control"
       placeholder="{{ 'First Name' | translate }}"
       ng-model="answer.value.firstName"
-      ng-model-options="{ debounce: 1000 }"
+      ng-model-options="{ debounce: 300 }"
       ng-required="block.required"
       ng-disabled="editBlock"
     />
@@ -18,7 +18,7 @@
       class="form-control"
       placeholder="{{ 'Last Name' | translate }}"
       ng-model="answer.value.lastName"
-      ng-model-options="{ debounce: 1000 }"
+      ng-model-options="{ debounce: 300 }"
       ng-required="block.required"
       ng-disabled="editBlock"
     />

--- a/app/views/blocks/numberQuestion.html
+++ b/app/views/blocks/numberQuestion.html
@@ -3,7 +3,7 @@
   type="number"
   class="form-control"
   ng-model="answer.value"
-  ng-model-options="{ debounce: 1000 }"
+  ng-model-options="{ debounce: 300 }"
   ng-disabled="false"
   ng-required="block.required"
   ng-min="block.content.range.min"

--- a/app/views/blocks/yearInSchoolQuestion.html
+++ b/app/views/blocks/yearInSchoolQuestion.html
@@ -9,7 +9,7 @@
       name="{{ block.id }}"
       ng-required="block.required"
       ng-model="answer.value"
-      ng-model-options="{ debounce: 1000 }"
+      ng-model-options="{ debounce: 300 }"
       ng-value="choice"
     />
     <strong>{{ choice }}</strong></label

--- a/app/views/eventDetails/eventInformation.html
+++ b/app/views/eventDetails/eventInformation.html
@@ -293,10 +293,7 @@
       <option></option>
     </select>
   </div>
-  <div
-    class="col-sm-5"
-    ng-if="conference.cruEvent && getEventTypes().length != 0"
-  >
+  <div class="col-sm-5" ng-if="conference.cruEvent && getEventTypes().length">
     <label translate>Event Type</label>
     <select
       class="form-control"

--- a/app/views/eventDetails/eventInformation.html
+++ b/app/views/eventDetails/eventInformation.html
@@ -301,7 +301,7 @@
     <select
       class="form-control"
       ng-model="conference.eventType"
-      ng-options="eventType.name for eventType in getEventTypes(conference.eventType) | orderBy:'name':false:sortNamesWithNA"
+      ng-options="eventType.id as eventType.name for eventType in getEventTypes(conference.eventType) | orderBy:'name':false:sortNamesWithNA"
     >
       <option></option>
     </select>

--- a/app/views/eventDetails/eventInformation.html
+++ b/app/views/eventDetails/eventInformation.html
@@ -288,7 +288,20 @@
     <select
       class="form-control"
       ng-model="conference.type"
-      ng-options="type.id as type.name for type in eventTypes | orderBy:'name':false:sortNamesWithNA"
+      ng-options="type.id as type.name for type in ministryPurposes | orderBy:'name':false:sortNamesWithNA"
+    >
+      <option></option>
+    </select>
+  </div>
+  <div
+    class="col-sm-5"
+    ng-if="conference.cruEvent && getEventTypes().length != 0"
+  >
+    <label translate>Event Type</label>
+    <select
+      class="form-control"
+      ng-model="conference.eventType"
+      ng-options="eventType.name for eventType in getEventTypes(conference.eventType) | orderBy:'name':false:sortNamesWithNA"
     >
       <option></option>
     </select>

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -105,11 +105,14 @@ describe('Controller: paymentModal', function () {
     scope.saveEvent();
 
     expect(scope.notify.message.toString()).toContain(
-      'Please enter Ministry Hosting Event.',
+      'Please enter Ministry Purpose.',
     );
 
+    //Expect that there will be event types given
+    expect(scope.getEventTypes().length).toBeGreaterThan(0);
+
     expect(scope.notify.message.toString()).toContain(
-      'Please enter Ministry Purpose.',
+      'Please enter which Event Type',
     );
   });
 

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -27,7 +27,7 @@ describe('Controller: eventDetails', function () {
   let testData;
   let $httpBackend;
 
-  describe('Conference with no type', () => {
+  describe('Conference with type', () => {
     beforeEach(
       angular.mock.inject(function (
         $rootScope,
@@ -47,6 +47,10 @@ describe('Controller: eventDetails', function () {
           $uibModal: _$uibModal_,
           permissions: {},
         });
+
+        scope.ministries = testData.ministries;
+        scope.ministryPurposes = testData.ministryPurposes;
+        scope.eventTypes = testData.eventTypes;
       }),
     );
 
@@ -245,16 +249,17 @@ describe('Controller: eventDetails', function () {
       expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(null);
     });
 
-    it('saveEvent() should validate the Ministry Purpose', () => {
+    it('saveEvent() should validate the conference', () => {
       scope.saveEvent();
-
+      //Expect that there will be event types given
+      expect(scope.getEventTypes().length).toBeGreaterThan(0);
       expect(scope.notify.message.toString()).toContain(
-        'Please enter Ministry Purpose.',
+        'Please enter which Event Type',
       );
     });
   });
 
-  describe('Conference with type', function () {
+  describe('Conference without type', function () {
     beforeEach(
       angular.mock.inject(function (
         $rootScope,
@@ -267,7 +272,7 @@ describe('Controller: eventDetails', function () {
         scope = $rootScope.$new();
         $httpBackend = _$httpBackend_;
 
-        testData.conference.type = '123';
+        testData.conference.type = null;
 
         $controller('eventDetailsCtrl', {
           $scope: scope,
@@ -279,14 +284,11 @@ describe('Controller: eventDetails', function () {
       }),
     );
 
-    it('saveEvent() should validate the conference', () => {
+    it('saveEvent() should validate the Ministry Purpose', () => {
       scope.saveEvent();
 
-      //Expect that there will be event types given
-      expect(scope.getEventTypes().length).toBeGreaterThan(0);
-
       expect(scope.notify.message.toString()).toContain(
-        'Please enter which Event Type',
+        'Please enter Ministry Purpose.',
       );
     });
   });

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -50,7 +50,6 @@ describe('Controller: eventDetails', function () {
 
         scope.ministries = testData.ministries;
         scope.ministryPurposes = testData.ministryPurposes;
-        scope.eventTypes = testData.eventTypes;
       }),
     );
 
@@ -85,6 +84,7 @@ describe('Controller: eventDetails', function () {
       expect(scope.conference.registrantTypes[3].name).toEqual(
         'Additional Type',
       );
+
       expect(scope.conference.registrantTypes[3].eform).toEqual(true);
     });
 
@@ -107,24 +107,6 @@ describe('Controller: eventDetails', function () {
         testData.conference.paymentGatewayType,
       );
     });
-
-    // it('saveEvent() should validate the conference', () => {
-    //   scope.saveEvent();
-
-    //   expect(scope.notify.message.toString()).toContain(
-    //     'Please enter Ministry Purpose.',
-    //   );
-
-    //   //Expect that there will be event types given
-    //   expect(scope.getEventTypes().length).toBeGreaterThan(0);
-
-    //   expect(scope.notify.message.toString()).toContain(
-    //     'Please enter which Event Type',
-    //   );
-
-    //   //Expect that there will be event types given
-    //   expect(scope.getEventTypes().length).toBeGreaterThan(0);
-    // });
 
     it('setPristine() should pristine the form', () => {
       scope.eventDetails = {

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -263,6 +263,7 @@ describe('Controller: eventDetails', function () {
           $uibModal: _$uibModal_,
           permissions: {},
         });
+        scope.ministries = testData.ministries;
       }),
     );
 

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -241,7 +241,7 @@ describe('Controller: eventDetails', function () {
     });
   });
 
-  describe('Conference without type', function () {
+  describe('Conference (Cru event) without type', function () {
     beforeEach(
       angular.mock.inject(function (
         $rootScope,
@@ -255,6 +255,7 @@ describe('Controller: eventDetails', function () {
         $httpBackend = _$httpBackend_;
 
         testData.conference.type = null;
+        testData.conference.eventType = null;
 
         $controller('eventDetailsCtrl', {
           $scope: scope,
@@ -272,6 +273,96 @@ describe('Controller: eventDetails', function () {
 
       expect(scope.notify.message.toString()).toContain(
         'Please enter Ministry Purpose.',
+      );
+
+      expect(scope.notify.message.toString()).not.toContain(
+        'Please enter which Event Type',
+      );
+    });
+  });
+
+  describe('Conference (Cru event) without ministry hosting', function () {
+    beforeEach(
+      angular.mock.inject(function (
+        $rootScope,
+        $controller,
+        _$uibModal_,
+        _testData_,
+        _$httpBackend_,
+      ) {
+        testData = _testData_;
+        scope = $rootScope.$new();
+        $httpBackend = _$httpBackend_;
+
+        testData.conference.ministry = null;
+        testData.conference.eventType = null;
+
+        $controller('eventDetailsCtrl', {
+          $scope: scope,
+          conference: testData.conference,
+          currencies: testData.currencies,
+          $uibModal: _$uibModal_,
+          permissions: {},
+        });
+        scope.ministries = testData.ministries;
+      }),
+    );
+
+    it('saveEvent() should validate the Ministry Hosting', () => {
+      scope.saveEvent();
+
+      expect(scope.notify.message.toString()).toContain(
+        'Please enter Ministry Hosting Event.',
+      );
+
+      expect(scope.notify.message.toString()).not.toContain(
+        'Please enter which Event Type',
+      );
+    });
+  });
+
+  describe('Conference that is not a Cru event', function () {
+    beforeEach(
+      angular.mock.inject(function (
+        $rootScope,
+        $controller,
+        _$uibModal_,
+        _testData_,
+        _$httpBackend_,
+      ) {
+        testData = _testData_;
+        scope = $rootScope.$new();
+        $httpBackend = _$httpBackend_;
+
+        testData.conference.cruEvent = null;
+        testData.conference.type = null;
+        testData.conference.ministry = null;
+        testData.conference.eventType = null;
+
+        $controller('eventDetailsCtrl', {
+          $scope: scope,
+          conference: testData.conference,
+          currencies: testData.currencies,
+          $uibModal: _$uibModal_,
+          permissions: {},
+        });
+        scope.ministries = testData.ministries;
+      }),
+    );
+
+    it('saveEvent() should not show errors of missing fields', () => {
+      scope.saveEvent();
+
+      expect(scope.notify.message.toString()).not.toContain(
+        'Please enter Ministry Purpose.',
+      );
+
+      expect(scope.notify.message.toString()).not.toContain(
+        'Please enter Ministry Hosting Event.',
+      );
+
+      expect(scope.notify.message.toString()).not.toContain(
+        'Please enter which Event Type',
       );
     });
   });

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -114,6 +114,9 @@ describe('Controller: paymentModal', function () {
     expect(scope.notify.message.toString()).toContain(
       'Please enter which Event Type',
     );
+
+    //Expect that there will be event types given
+    expect(scope.getEventTypes().length).toBeGreaterThan(0);
   });
 
   it('setPristine() should pristine the form', () => {

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -1,6 +1,6 @@
 import 'angular-mocks';
 
-describe('Controller: paymentModal', function () {
+describe('Controller: eventDetails', function () {
   var scope;
 
   beforeEach(angular.mock.module('confRegistrationWebApp'));
@@ -27,218 +27,267 @@ describe('Controller: paymentModal', function () {
   let testData;
   let $httpBackend;
 
-  beforeEach(
-    angular.mock.inject(function (
-      $rootScope,
-      $controller,
-      _$uibModal_,
-      _testData_,
-      _$httpBackend_,
-    ) {
-      testData = _testData_;
-      scope = $rootScope.$new();
-      $httpBackend = _$httpBackend_;
+  describe('Conference with no type', () => {
+    beforeEach(
+      angular.mock.inject(function (
+        $rootScope,
+        $controller,
+        _$uibModal_,
+        _testData_,
+        _$httpBackend_,
+      ) {
+        testData = _testData_;
+        scope = $rootScope.$new();
+        $httpBackend = _$httpBackend_;
 
-      $controller('eventDetailsCtrl', {
-        $scope: scope,
-        conference: testData.conference,
-        currencies: testData.currencies,
-        $uibModal: _$uibModal_,
-        permissions: {},
-      });
-    }),
-  );
+        $controller('eventDetailsCtrl', {
+          $scope: scope,
+          conference: testData.conference,
+          currencies: testData.currencies,
+          $uibModal: _$uibModal_,
+          permissions: {},
+        });
+      }),
+    );
 
-  it('changeTab() should change tab', function () {
-    scope.changeTab('paymentOptions');
+    it('changeTab() should change tab', function () {
+      scope.changeTab('paymentOptions');
 
-    expect(scope.activeTab).toBe('paymentOptions');
-  });
-
-  it('addRegType should add reg type', function () {
-    var totalRegTypes = scope.conference.registrantTypes.length;
-
-    var modal = scope.addRegType();
-    modal.close({
-      name: 'Additional Type',
-      defaultTypeKey: '',
+      expect(scope.activeTab).toBe('paymentOptions');
     });
 
-    expect(scope.conference.registrantTypes.length).toBe(totalRegTypes + 1);
-  });
+    it('addRegType should add reg type', function () {
+      var totalRegTypes = scope.conference.registrantTypes.length;
 
-  it('addRegType() should set reg type eform to value of conference eform', () => {
-    const totalRegTypes = scope.conference.registrantTypes.length;
-    scope.conference.eform = true;
-    const modal = scope.addRegType();
-    modal.close({
-      name: 'Additional Type',
-      defaultTypeKey: '',
+      var modal = scope.addRegType();
+      modal.close({
+        name: 'Additional Type',
+        defaultTypeKey: '',
+      });
+
+      expect(scope.conference.registrantTypes.length).toBe(totalRegTypes + 1);
     });
 
-    expect(scope.conference.registrantTypes.length).toBe(totalRegTypes + 1);
-    expect(scope.conference.registrantTypes[3].name).toEqual('Additional Type');
-    expect(scope.conference.registrantTypes[3].eform).toEqual(true);
-  });
-
-  it('deleteRegType should remove reg type', function () {
-    var totalRegTypes = scope.conference.registrantTypes.length;
-
-    scope.deleteRegType(scope.conference.registrantTypes[0].id);
-
-    expect(scope.conference.registrantTypes.length).toBe(totalRegTypes - 1);
-  });
-
-  it('anyPaymentMethodAccepted should be true', function () {
-    expect(
-      scope.anyPaymentMethodAccepted(scope.conference.registrantTypes[0]),
-    ).toBe(true);
-  });
-
-  it("getPaymentGatewayType should return the conference's paymentGatewayType", function () {
-    expect(scope.getPaymentGatewayType()).toBe(
-      testData.conference.paymentGatewayType,
-    );
-  });
-
-  it('saveEvent() should validate the conference', () => {
-    scope.saveEvent();
-
-    expect(scope.notify.message.toString()).toContain(
-      'Please enter Ministry Purpose.',
-    );
-
-    //Expect that there will be event types given
-    expect(scope.getEventTypes().length).toBeGreaterThan(0);
-
-    expect(scope.notify.message.toString()).toContain(
-      'Please enter which Event Type',
-    );
-
-    //Expect that there will be event types given
-    expect(scope.getEventTypes().length).toBeGreaterThan(0);
-  });
-
-  it('setPristine() should pristine the form', () => {
-    scope.eventDetails = {
-      $setPristine() {},
-    };
-
-    const setPristine = spyOn(scope.eventDetails, '$setPristine');
-
-    scope.setPristine();
-
-    expect(setPristine).toHaveBeenCalledWith();
-  });
-
-  it('resetImage should set image and includeImageToAllPages to the value taken from the conference', () => {
-    scope.image.includeImageToAllPages = false;
-    scope.image.imageSrc = 'new-image';
-    scope.resetImage();
-
-    expect(scope.image.includeImageToAllPages).toEqual(
-      scope.conference.image.includeImageToAllPages,
-    );
-
-    expect(scope.image.image).toEqual(scope.conference.image.image);
-  });
-
-  it('saveImage should save image and includeImageToAllPages', () => {
-    scope.image.includeImageToAllPages = false;
-    scope.image.image = 'new-image';
-    $httpBackend
-      .whenPUT(/^conferences\/[-a-zA-Z0-9]+\/image\.*/)
-      .respond((verb, url, data) => {
-        return [200, data, {}];
+    it('addRegType() should set reg type eform to value of conference eform', () => {
+      const totalRegTypes = scope.conference.registrantTypes.length;
+      scope.conference.eform = true;
+      const modal = scope.addRegType();
+      modal.close({
+        name: 'Additional Type',
+        defaultTypeKey: '',
       });
-    scope.saveImage();
 
-    $httpBackend.flush();
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
+      expect(scope.conference.registrantTypes.length).toBe(totalRegTypes + 1);
+      expect(scope.conference.registrantTypes[3].name).toEqual(
+        'Additional Type',
+      );
+      expect(scope.conference.registrantTypes[3].eform).toEqual(true);
+    });
 
-    expect(scope.image.includeImageToAllPages).toEqual(
-      scope.conference.image.includeImageToAllPages,
-    );
+    it('deleteRegType should remove reg type', function () {
+      var totalRegTypes = scope.conference.registrantTypes.length;
 
-    expect(scope.image.image).toEqual(scope.conference.image.image);
+      scope.deleteRegType(scope.conference.registrantTypes[0].id);
+
+      expect(scope.conference.registrantTypes.length).toBe(totalRegTypes - 1);
+    });
+
+    it('anyPaymentMethodAccepted should be true', function () {
+      expect(
+        scope.anyPaymentMethodAccepted(scope.conference.registrantTypes[0]),
+      ).toBe(true);
+    });
+
+    it("getPaymentGatewayType should return the conference's paymentGatewayType", function () {
+      expect(scope.getPaymentGatewayType()).toBe(
+        testData.conference.paymentGatewayType,
+      );
+    });
+
+    // it('saveEvent() should validate the conference', () => {
+    //   scope.saveEvent();
+
+    //   expect(scope.notify.message.toString()).toContain(
+    //     'Please enter Ministry Purpose.',
+    //   );
+
+    //   //Expect that there will be event types given
+    //   expect(scope.getEventTypes().length).toBeGreaterThan(0);
+
+    //   expect(scope.notify.message.toString()).toContain(
+    //     'Please enter which Event Type',
+    //   );
+
+    //   //Expect that there will be event types given
+    //   expect(scope.getEventTypes().length).toBeGreaterThan(0);
+    // });
+
+    it('setPristine() should pristine the form', () => {
+      scope.eventDetails = {
+        $setPristine() {},
+      };
+
+      const setPristine = spyOn(scope.eventDetails, '$setPristine');
+
+      scope.setPristine();
+
+      expect(setPristine).toHaveBeenCalledWith();
+    });
+
+    it('resetImage should set image and includeImageToAllPages to the value taken from the conference', () => {
+      scope.image.includeImageToAllPages = false;
+      scope.image.imageSrc = 'new-image';
+      scope.resetImage();
+
+      expect(scope.image.includeImageToAllPages).toEqual(
+        scope.conference.image.includeImageToAllPages,
+      );
+
+      expect(scope.image.image).toEqual(scope.conference.image.image);
+    });
+
+    it('saveImage should save image and includeImageToAllPages', () => {
+      scope.image.includeImageToAllPages = false;
+      scope.image.image = 'new-image';
+      $httpBackend
+        .whenPUT(/^conferences\/[-a-zA-Z0-9]+\/image\.*/)
+        .respond((verb, url, data) => {
+          return [200, data, {}];
+        });
+      scope.saveImage();
+
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+
+      expect(scope.image.includeImageToAllPages).toEqual(
+        scope.conference.image.includeImageToAllPages,
+      );
+
+      expect(scope.image.image).toEqual(scope.conference.image.image);
+    });
+
+    it('deleteImage should delete image and set includeImageToAllPages to false', () => {
+      $httpBackend
+        .whenPUT(/^conferences\/[-a-zA-Z0-9]+\/image\.*/)
+        .respond((verb, url, data) => {
+          return [200, data, {}];
+        });
+      scope.deleteImage();
+
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+
+      expect(scope.conference.image.includeImageToAllPages).toEqual(false);
+
+      expect(scope.conference.image.image).toEqual('');
+    });
+
+    it('createLiabilityQuestions() should create liability related questions on first page', () => {
+      scope.createLiabilityQuestions();
+
+      expect(
+        scope.conference.registrationPages[0].blocks[
+          scope.conference.registrationPages[0].blocks.length - 1
+        ].title,
+      ).toEqual('Guardian Email');
+
+      expect(
+        scope.conference.registrationPages[0].blocks[
+          scope.conference.registrationPages[0].blocks.length - 2
+        ].title,
+      ).toEqual('Guardian Name');
+
+      expect(
+        scope.conference.registrationPages[0].blocks[
+          scope.conference.registrationPages[0].blocks.length - 3
+        ].title,
+      ).toEqual('Are you under 18?');
+    });
+
+    it('updateLiabilityQuestions() should delete liability related questions', () => {
+      scope.createLiabilityQuestions();
+
+      expect(scope.conference.registrationPages[0].blocks[3].title).toEqual(
+        'Guardian Email',
+      );
+
+      expect(scope.conference.registrationPages[0].blocks[3].tag).toEqual(
+        'EFORM',
+      );
+
+      expect(scope.conference.registrationPages[0].blocks[2].title).toEqual(
+        'Guardian Name',
+      );
+
+      expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(
+        'EFORM',
+      );
+
+      expect(scope.conference.registrationPages[0].blocks[1].title).toEqual(
+        'Are you under 18?',
+      );
+
+      expect(scope.conference.registrationPages[0].blocks[1].tag).toEqual(
+        'EFORM',
+      );
+
+      expect(scope.conference.registrationPages[0].blocks.length).toBe(4);
+
+      scope.updateLiabilityQuestions();
+      $httpBackend.flush();
+
+      expect(scope.conference.registrationPages[0].blocks[3].tag).toEqual(null);
+
+      expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(null);
+
+      expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(null);
+    });
+
+    it('saveEvent() should validate the Ministry Purpose', () => {
+      scope.saveEvent();
+
+      expect(scope.notify.message.toString()).toContain(
+        'Please enter Ministry Purpose.',
+      );
+    });
   });
 
-  it('deleteImage should delete image and set includeImageToAllPages to false', () => {
-    $httpBackend
-      .whenPUT(/^conferences\/[-a-zA-Z0-9]+\/image\.*/)
-      .respond((verb, url, data) => {
-        return [200, data, {}];
-      });
-    scope.deleteImage();
+  describe('Conference with type', function () {
+    beforeEach(
+      angular.mock.inject(function (
+        $rootScope,
+        $controller,
+        _$uibModal_,
+        _testData_,
+        _$httpBackend_,
+      ) {
+        testData = _testData_;
+        scope = $rootScope.$new();
+        $httpBackend = _$httpBackend_;
 
-    $httpBackend.flush();
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
+        testData.conference.type = '123';
 
-    expect(scope.conference.image.includeImageToAllPages).toEqual(false);
-
-    expect(scope.conference.image.image).toEqual('');
-  });
-
-  it('createLiabilityQuestions() should create liability related questions on first page', () => {
-    scope.createLiabilityQuestions();
-
-    expect(
-      scope.conference.registrationPages[0].blocks[
-        scope.conference.registrationPages[0].blocks.length - 1
-      ].title,
-    ).toEqual('Guardian Email');
-
-    expect(
-      scope.conference.registrationPages[0].blocks[
-        scope.conference.registrationPages[0].blocks.length - 2
-      ].title,
-    ).toEqual('Guardian Name');
-
-    expect(
-      scope.conference.registrationPages[0].blocks[
-        scope.conference.registrationPages[0].blocks.length - 3
-      ].title,
-    ).toEqual('Are you under 18?');
-  });
-
-  it('updateLiabilityQuestions() should delete liability related questions', () => {
-    scope.createLiabilityQuestions();
-
-    expect(scope.conference.registrationPages[0].blocks[3].title).toEqual(
-      'Guardian Email',
+        $controller('eventDetailsCtrl', {
+          $scope: scope,
+          conference: testData.conference,
+          currencies: testData.currencies,
+          $uibModal: _$uibModal_,
+          permissions: {},
+        });
+      }),
     );
 
-    expect(scope.conference.registrationPages[0].blocks[3].tag).toEqual(
-      'EFORM',
-    );
+    it('saveEvent() should validate the conference', () => {
+      scope.saveEvent();
 
-    expect(scope.conference.registrationPages[0].blocks[2].title).toEqual(
-      'Guardian Name',
-    );
+      //Expect that there will be event types given
+      expect(scope.getEventTypes().length).toBeGreaterThan(0);
 
-    expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(
-      'EFORM',
-    );
-
-    expect(scope.conference.registrationPages[0].blocks[1].title).toEqual(
-      'Are you under 18?',
-    );
-
-    expect(scope.conference.registrationPages[0].blocks[1].tag).toEqual(
-      'EFORM',
-    );
-
-    expect(scope.conference.registrationPages[0].blocks.length).toBe(4);
-
-    scope.updateLiabilityQuestions();
-    $httpBackend.flush();
-
-    expect(scope.conference.registrationPages[0].blocks[3].tag).toEqual(null);
-
-    expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(null);
-
-    expect(scope.conference.registrationPages[0].blocks[2].tag).toEqual(null);
+      expect(scope.notify.message.toString()).toContain(
+        'Please enter which Event Type',
+      );
+    });
   });
 });

--- a/test/spec/mockHttpBackend.spec.js
+++ b/test/spec/mockHttpBackend.spec.js
@@ -163,25 +163,4 @@ angular
 
         return [200, answer];
       });
-
-    $httpBackend.whenGET(/^ministries\/?$/).respond(() => {
-      console.log('ministries', arguments);
-
-      var eventTypes = testData.eventTypes;
-      return [200, eventTypes, {}];
-    });
-
-    $httpBackend.whenGET(/^types\/?$/).respond(() => {
-      console.log('types', arguments);
-
-      var ministryPurposes = testData.ministryPurposes;
-      return [200, ministryPurposes, {}];
-    });
-
-    $httpBackend.whenGET(/^event\/types\/?$/).respond(() => {
-      console.log('eventTypes', arguments);
-
-      var eventTypes = testData.eventTypes;
-      return [200, eventTypes, {}];
-    });
   });

--- a/test/spec/mockHttpBackend.spec.js
+++ b/test/spec/mockHttpBackend.spec.js
@@ -163,4 +163,25 @@ angular
 
         return [200, answer];
       });
+
+    $httpBackend.whenGET(/^ministries\/?$/).respond(() => {
+      console.log('ministries', arguments);
+
+      var eventTypes = testData.eventTypes;
+      return [200, eventTypes, {}];
+    });
+
+    $httpBackend.whenGET(/^types\/?$/).respond(() => {
+      console.log('types', arguments);
+
+      var ministryPurposes = testData.ministryPurposes;
+      return [200, ministryPurposes, {}];
+    });
+
+    $httpBackend.whenGET(/^event\/types\/?$/).respond(() => {
+      console.log('eventTypes', arguments);
+
+      var eventTypes = testData.eventTypes;
+      return [200, eventTypes, {}];
+    });
   });

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -5,6 +5,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     id: 'c63b8abf-52ff-4cc4-afbc-5923b01f1ab0',
     name: 'Big Event 2015',
     description: '',
+    abbreviation: 'TEST',
     registrationPages: [
       {
         id: '5c69bfcc-9e35-4bd8-8358-fe50fd86052d',
@@ -494,7 +495,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     customPaymentEmailText: null,
     rideshareEnabled: false,
     rideshareEmailContent: null,
-    allowEditRegistrationAfterComplete: true,
+    allowEditRegistrationAfterComplete: false,
     checkPayableTo: 'Test Admin',
     checkMailingAddress: '100 Lake Hart Dr.',
     checkMailingCity: 'Orlando',
@@ -1498,5 +1499,57 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     { code: 'ZWD', name: 'Zimbabwean Dollar (1980-2008) ZWD' },
     { code: 'ZWR', name: 'Zimbabwean Dollar (2008) ZWR' },
     { code: 'ZWL', name: 'Zimbabwean Dollar (2009) ZWL' },
+  ];
+
+  this.eventTypes = [
+    {
+      id: '87b02878-5070-473b-bb07-3b2d899b46d6',
+      strategies: [],
+      activities: [],
+      name: 'Athletes in Action',
+      $$hashKey: 'object:665',
+    },
+    {
+      id: 'f6d31fe3-7078-4fac-a37b-9596d57558e9',
+      strategies: [
+        {
+          id: '9769eb02-1075-45fc-ae03-c7733627a1ef',
+          name: 'N/A',
+        },
+        {
+          id: 'd7d42d11-59b0-4d1f-9906-3ab706c63e8a',
+          name: 'Bridges',
+        },
+      ],
+      activities: [],
+      name: 'Campus - National Team/Strategy',
+      $$hashKey: 'object:666',
+    },
+  ];
+  // Also known as types
+  this.ministryPurposes = [
+    {
+      id: 'ef4ffa14-0b02-4d7e-915e-77ccf958f5b9',
+      name: 'Ministry Conference/Event',
+      $$hashKey: 'object:687',
+    },
+    {
+      id: '0ff7a8c9-0084-48fb-9077-893bf8b94fd7',
+      name: 'Ministry Mission Trip',
+      $$hashKey: 'object:688',
+    },
+  ];
+
+  this.eventTypes = [
+    {
+      id: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
+      name: 'Fall Retreat/Getaway',
+      $$hashKey: 'object:694',
+    },
+    {
+      id: 'b281a0f3-b0bc-4f8e-9f49-0c3adfe25584',
+      name: 'Mobilization/Recruiting',
+      $$hashKey: 'object:695',
+    },
   ];
 });

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -511,7 +511,6 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     ministry: 'f6d31fe3-7078-4fac-a37b-9596d57558e9',
     eventType: null,
     type: 'ef4ffa14-0b02-4d7e-915e-77ccf958f5b9',
-    //eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
     virtual: false,
     image: {
       image:
@@ -1549,17 +1548,4 @@ angular.module('confRegistrationWebApp').service('testData', function () {
       $hashKey: 'object:688',
     },
   ];
-
-  // this.eventTypes = [
-  //   {
-  //     id: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
-  //     name: 'Fall Retreat/Getaway',
-  //     $hashKey: 'object:694',
-  //   },
-  //   {
-  //     id: 'b281a0f3-b0bc-4f8e-9f49-0c3adfe25584',
-  //     name: 'Mobilization/Recruiting',
-  //     $hashKey: 'object:695',
-  //   },
-  // ];
 });

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -510,7 +510,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     cruEvent: true,
     ministry: 'f6d31fe3-7078-4fac-a37b-9596d57558e9',
     eventType: null,
-    type: null,
+    type: '123',
     //eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
     virtual: false,
     image: {
@@ -1501,13 +1501,13 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     { code: 'ZWL', name: 'Zimbabwean Dollar (2009) ZWL' },
   ];
 
-  this.eventTypes = [
+  this.ministries = [
     {
       id: '87b02878-5070-473b-bb07-3b2d899b46d6',
       strategies: [],
       activities: [],
       name: 'Athletes in Action',
-      $$hashKey: 'object:665',
+      $hashKey: 'object:665',
     },
     {
       id: 'f6d31fe3-7078-4fac-a37b-9596d57558e9',
@@ -1523,7 +1523,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
       ],
       activities: [],
       name: 'Campus - National Team/Strategy',
-      $$hashKey: 'object:666',
+      $hashKey: 'object:666',
     },
   ];
   // Also known as types
@@ -1531,12 +1531,12 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     {
       id: 'ef4ffa14-0b02-4d7e-915e-77ccf958f5b9',
       name: 'Ministry Conference/Event',
-      $$hashKey: 'object:687',
+      $hashKey: 'object:687',
     },
     {
       id: '0ff7a8c9-0084-48fb-9077-893bf8b94fd7',
       name: 'Ministry Mission Trip',
-      $$hashKey: 'object:688',
+      $hashKey: 'object:688',
     },
   ];
 
@@ -1544,12 +1544,12 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     {
       id: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
       name: 'Fall Retreat/Getaway',
-      $$hashKey: 'object:694',
+      $hashKey: 'object:694',
     },
     {
       id: 'b281a0f3-b0bc-4f8e-9f49-0c3adfe25584',
       name: 'Mobilization/Recruiting',
-      $$hashKey: 'object:695',
+      $hashKey: 'object:695',
     },
   ];
 });

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -510,7 +510,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     cruEvent: true,
     ministry: 'f6d31fe3-7078-4fac-a37b-9596d57558e9',
     eventType: null,
-    type: '123',
+    type: 'ef4ffa14-0b02-4d7e-915e-77ccf958f5b9',
     //eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
     virtual: false,
     image: {

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -507,6 +507,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     accountNumber: null,
     glAccount: null,
     cruEvent: true,
+    eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
     virtual: false,
     image: {
       image:

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -507,7 +507,10 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     accountNumber: null,
     glAccount: null,
     cruEvent: true,
-    eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
+    ministry: 'string:f6d31fe3-7078-4fac-a37b-9596d57558e9',
+    eventType: null,
+    type: null,
+    //eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
     virtual: false,
     image: {
       image:

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -1522,6 +1522,16 @@ angular.module('confRegistrationWebApp').service('testData', function () {
         },
       ],
       activities: [],
+      eventTypes: [
+        {
+          id: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
+          name: 'Fall Retreat/Getaway',
+        },
+        {
+          id: 'b281a0f3-b0bc-4f8e-9f49-0c3adfe25584',
+          name: 'Mobilization/Recruiting',
+        },
+      ],
       name: 'Campus - National Team/Strategy',
       $hashKey: 'object:666',
     },
@@ -1540,16 +1550,16 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     },
   ];
 
-  this.eventTypes = [
-    {
-      id: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
-      name: 'Fall Retreat/Getaway',
-      $hashKey: 'object:694',
-    },
-    {
-      id: 'b281a0f3-b0bc-4f8e-9f49-0c3adfe25584',
-      name: 'Mobilization/Recruiting',
-      $hashKey: 'object:695',
-    },
-  ];
+  // this.eventTypes = [
+  //   {
+  //     id: 'cfc2b308-566b-432b-bee4-4ed60fec5608',
+  //     name: 'Fall Retreat/Getaway',
+  //     $hashKey: 'object:694',
+  //   },
+  //   {
+  //     id: 'b281a0f3-b0bc-4f8e-9f49-0c3adfe25584',
+  //     name: 'Mobilization/Recruiting',
+  //     $hashKey: 'object:695',
+  //   },
+  // ];
 });

--- a/test/spec/testData.spec.js
+++ b/test/spec/testData.spec.js
@@ -507,7 +507,7 @@ angular.module('confRegistrationWebApp').service('testData', function () {
     accountNumber: null,
     glAccount: null,
     cruEvent: true,
-    ministry: 'string:f6d31fe3-7078-4fac-a37b-9596d57558e9',
+    ministry: 'f6d31fe3-7078-4fac-a37b-9596d57558e9',
     eventType: null,
     type: null,
     //eventType: 'cfc2b308-566b-432b-bee4-4ed60fec5608',

--- a/test/spec/testRegistrantTypeData.spec.js
+++ b/test/spec/testRegistrantTypeData.spec.js
@@ -7,7 +7,7 @@ angular
       id: '0dc61eeb-6932-4d09-b04f-9def3915fd4c',
       name: 'EVENT 607',
       description: null,
-      abbreviation: null,
+      abbreviation: 'TEST',
       registrationPages: [
         {
           id: 'ca2ea3a4-008b-4a9c-a653-8c5ecd980e82',
@@ -373,7 +373,7 @@ angular
       combineSpouseRegistrations: false,
       loggedInUserPermissionLevel: null,
       cssUrl: null,
-      cruEvent: false,
+      cruEvent: true,
       eventType: null,
     };
 

--- a/test/spec/testRegistrantTypeData.spec.js
+++ b/test/spec/testRegistrantTypeData.spec.js
@@ -374,6 +374,7 @@ angular
       loggedInUserPermissionLevel: null,
       cssUrl: null,
       cruEvent: false,
+      eventType: null,
     };
 
     this.registration = {

--- a/types/conference.ts
+++ b/types/conference.ts
@@ -126,6 +126,7 @@ export interface Conference {
   strategy: string | null;
   ministryActivity: string | null;
   type: string;
+  eventType: string | null;
   eform: boolean;
   workProject: boolean;
   virtual: boolean;


### PR DESCRIPTION
## Description

https://jira.cru.org/browse/EVENT-821

On the Details tab of an event ERT we need to be able to collect the event type in order to capture the participant journey and know the event journey the Cru participant has followed during their time with Cru.  While the list is Campus specific the same process could be used for other ministries based on the participant event journey they with to follow.

 

When an admin answers "Yes" this is a Cru event we can use the "Ministry Hosting Event" dropdown to determine what event types would be needed. 

In this case if the Ministry Hosting the event as “Campus - Field Team/Strategy” or “Campus - National Team/Strategy” and I would also suggest that when the Ministry Purpose is selected as “Ministry Conference/Event” or "Ministry Mission Trip".  The following list should also be added to the right of the Ministry Purpose box with a tile "Event Type". 

Event Type
Fall Retreat/Getaway
Mobilization/Recruiting
Spring Break
Winter Conference
N/A
 

Be mindful to not break existing links to the Liability form process that currently uses the "Ministry Hosting Event" and "Ministry Purpose" dropdowns. 

## Changes I made


Companion PR https://github.com/CruGlobal/ert-api/pull/1029