### PR TITLE
A recent deployment broke some code on the event details page, result…

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -913,13 +913,14 @@ angular
         });
         const payload = angular.copy($scope.conference);
         // Remove unwanted properties from sending to API.
-        payload.registrantTypes = payload.registrantTypes.map((p) => {
-          p.allowedRegistrantTypeSet = p.allowedRegistrantTypeSet.map((t) => {
-            delete t.name;
-            delete t.selected;
-            return t;
-          });
-          return p;
+        payload.registrantTypes = payload.registrantTypes.map((regType) => {
+          regType.allowedRegistrantTypeSet =
+            regType.allowedRegistrantTypeSet.map((set) => {
+              delete set.name;
+              delete set.selected;
+              return set;
+            });
+          return regType;
         });
         $http({
           method: 'PUT',

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -108,10 +108,14 @@ angular
               });
               return {
                 id: existingChild ? existingChild.id : uuid(),
+                name: t.name,
                 childRegistrantTypeId: t.id,
                 numberOfChildRegistrants: existingChild
                   ? existingChild.numberOfChildRegistrants
                   : 0,
+                selected:
+                  existingChild !== undefined &&
+                  existingChild.selected !== false,
               };
             },
           );

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -912,6 +912,15 @@ angular
           });
         });
         const payload = angular.copy($scope.conference);
+        // Remove unwanted properties from sending to API.
+        payload.registrantTypes = payload.registrantTypes.map((p) => {
+          p.allowedRegistrantTypeSet = p.allowedRegistrantTypeSet.map((t) => {
+            delete t.name;
+            delete t.selected;
+            return t;
+          });
+          return p;
+        });
         $http({
           method: 'PUT',
           url: 'conferences/' + conference.id,


### PR DESCRIPTION
## Description
A recent deployment broke some code on the event details page, resulting in the Associated Registrant Types no longer showing. This fix adds back the code which was removed.

## Changes
- Adding back code which was there previously. Ensuring `name` and `selected` are defined on `types` in the  `allowedRegistrantTypeSet` array.

Deployment which had breaking changes https://github.com/CruGlobal/conf-registration-web/pull/835