### PR TITLE
Correction Associated Registrant Types after merge

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -108,10 +108,14 @@ angular
               });
               return {
                 id: existingChild ? existingChild.id : uuid(),
+                name: t.name,
                 childRegistrantTypeId: t.id,
                 numberOfChildRegistrants: existingChild
                   ? existingChild.numberOfChildRegistrants
                   : 0,
+                selected:
+                  existingChild !== undefined &&
+                  existingChild.selected !== false,
               };
             },
           );


### PR DESCRIPTION
* A recent deployment broke some code on the event details page, resulting in the Associated Registrant Types no longer showing. This fix adds back the code which was removed.

* Had to remove unwanted properties from the conference copied object, which is being sent to the API. properties were causing errors.

*  I added this fix a few days ago but part of it was removed from Prod when it was merged. The code which was removed didn't show on the PR as edited files, which is why we didn't catch it.