### PR TITLE
Fix Date Format

### DIFF
--- a/app/scripts/directives/datepicker.js
+++ b/app/scripts/directives/datepicker.js
@@ -15,8 +15,11 @@ angular
       controller: function ($timeout, $scope) {
         $scope.updateTimeStamp = function (timestamp) {
           $scope.$apply(function () {
+            let dateSaveFormat = $scope.monthYearOnly
+              ? 'YYYY-MM'
+              : 'YYYY-MM-DD HH:mm:ss';
             $scope.localModel = moment(new Date(timestamp)).format(
-              'YYYY-MM-DD HH:mm:ss',
+              dateSaveFormat,
             );
           });
         };


### PR DESCRIPTION
Change the format of saved data for the graduation date question. The API wants YYYY-MM as opposed to the usual date format that includes the day and time.