### PR TITLE
Reimplementing the reverted PR #842/#843 but not included changes wer…

### DIFF
--- a/app/scripts/controllers/registration.js
+++ b/app/scripts/controllers/registration.js
@@ -367,6 +367,16 @@ angular
         var currentRegistrant = _.find($scope.currentRegistration.registrants, {
           id: $scope.currentRegistrant,
         });
+        const invalidBlocks = _.find(currentRegistration.registrants, {
+          id: currentRegistrant.id,
+        })
+          ? validateRegistrant.validate(
+              conference,
+              _.find(currentRegistration.registrants, {
+                id: currentRegistrant.id,
+              }),
+            )
+          : [];
         var answersToSave = [];
 
         angular.forEach(
@@ -376,8 +386,9 @@ angular
               id: a.id,
             });
             if (
-              angular.isUndefined(savedAnswer) ||
-              !angular.equals(savedAnswer.value, a.value)
+              (angular.isUndefined(savedAnswer) ||
+                !angular.equals(savedAnswer.value, a.value)) &&
+              !invalidBlocks.includes(a.blockId)
             ) {
               if ($scope.registerMode !== 'preview') {
                 answersToSave.push($http.put('answers/' + a.id, a));

--- a/app/scripts/directives/datepicker.js
+++ b/app/scripts/directives/datepicker.js
@@ -14,9 +14,9 @@ angular
       },
       controller: function ($timeout, $scope) {
         $scope.updateTimeStamp = function (timestamp) {
-          //For Graduation date question, set the day to 1. The API needs the day but that could change in the future.
+          //For the Graduation date question, set the day to 10. The API needs the day but that could change in the future.
           timestamp = $scope.monthYearOnly
-            ? moment(new Date(timestamp)).set('date', 1)
+            ? moment(new Date(timestamp)).set('date', 10)
             : timestamp;
           $scope.$apply(function () {
             let dateSaveFormat = $scope.monthYearOnly

--- a/test/spec/directives/datepicker.spec.js
+++ b/test/spec/directives/datepicker.spec.js
@@ -21,7 +21,7 @@ describe('Directive: datepicker', function () {
   it('Sets the date to the correct format based on the type of date question', function () {
     scope.updateTimeStamp(new Date('02/05/1994'));
 
-    expect(scope.localModel).toBe('1994-02-01');
+    expect(scope.localModel).toBe('1994-02-10');
 
     scope.monthYearOnly = false;
 


### PR DESCRIPTION
## Description
Re-adding changes which were on PR #842 but not included changes where localModel is set.
https://secure.helpscout.net/conversation/2355398292/1014142?folderId=7296147

## Changes
- Check to see if questions are invalid before pushing them to the database.
- Set graduation date day to 10 so it's the same month across all timezones.
