### PR TITLE
Event banner oversized on mobile devices 

### DIFF
--- a/app/styles/user-registration.scss
+++ b/app/styles/user-registration.scss
@@ -173,6 +173,6 @@ body.user-registration {
     padding-bottom: 25px;
   }
   img {
-    max-width: 582px;
+    max-width: min(582px, 100%);
   }
 }


### PR DESCRIPTION
## Description
A user complained that the banner was making the event page not responsive. - https://secure.helpscout.net/conversation/2389694143/1033842?folderId=7599856

## Changes
- Added CSS `min()` function to determine which is smaller, 100% of container width or 582px.