### PR TITLE
EVENT-843 - FedCM Beta Testing

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -278,7 +278,7 @@ AddDefaultCharset utf-8
 # see the specification: http://w3.org/TR/CSP).
 
 # <IfModule mod_headers.c>
-#    Header set Content-Security-Policy "script-src 'self'; object-src 'self'"
+#    Header set Content-Security-Policy "script-src 'self' https://accounts.google.com/gsi/client; object-src 'self'"
 #    <FilesMatch "\.(appcache|crx|css|eot|gif|htc|ico|jpe?g|js|m4a|m4v|manifest|mp4|oex|oga|ogg|ogv|otf|pdf|png|safariextz|svg|svgz|ttf|vcf|webapp|webm|webp|woff|xml|xpi)$">
 #        Header unset Content-Security-Policy
 #    </FilesMatch>

--- a/app/scripts/components/GoogleLogin/GoogleLogin.tsx
+++ b/app/scripts/components/GoogleLogin/GoogleLogin.tsx
@@ -40,6 +40,7 @@ const GoogleLogin = ({ $http, $document, envService }: GoogleLoginProps) => {
       <>
         <div
           id="g_id_onload"
+          data-use_fedcm_for_prompt="true"
           data-client_id={clientId}
           data-auto_prompt="true"
           data-nonce={googleNonce}


### PR DESCRIPTION
## Description
https://jira.cru.org/browse/EVENT-843
Google login is changing and we need to be ready for it, we should hop on the FedCM beta to make sure this move won't break ERT's ability to login via Google.

https://developers.googleblog.com/2023/08/announcing-federated-credential-management-beta-for-gis.html

## Changes I made
I followed these steps: https://developers.google.com/identity/gsi/web/guides/fedcm-migration