### PR TITLE
[no-Jira] Sync yarn.lock and package.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,7 +1280,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cruglobal/cru-payments@1.2.4":
+"@cruglobal/cru-payments@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cruglobal/cru-payments/-/cru-payments-1.2.4.tgz#2794be3141c40232539b18581d1038648470ac2d"
   integrity sha512-hbw/e4T0lq20XCDGDsuhl8wr/8ruhhi94qcF7DuLh5HyGuwaaVvxi0yDRj9irsL6CIcsmgwDimOmOlvyD9BwaA==


### PR DESCRIPTION
It looks like yarn.lock and package.json got out of sync after #834. Every time I run `yarn install`, yarn makes these changes to the lockfile.