### PR TITLE
[EVENT-845] Disable editing staff profile info

### DIFF
--- a/app/scripts/directives/blocks.js
+++ b/app/scripts/directives/blocks.js
@@ -25,9 +25,10 @@ angular.module('confRegistrationWebApp').directive('nameQuestion', function () {
         $scope.answer.value = {};
       }
 
-      $scope.lockedStaffProfileBlock =
-        !!$rootScope.globalUser().employeeId &&
-        $scope.block.profileType === 'NAME';
+      const user = $rootScope.globalUser();
+      $scope.lockedStaffProfileBlock = Boolean(
+        user && user.employeeId && $scope.block.profileType === 'NAME',
+      );
     },
   };
 });
@@ -69,9 +70,10 @@ angular
       templateUrl: emailQuestionTemplate,
       restrict: 'E',
       controller: function ($rootScope, $scope) {
-        $scope.lockedStaffProfileBlock =
-          !!$rootScope.globalUser().employeeId &&
-          $scope.block.profileType === 'EMAIL';
+        const user = $rootScope.globalUser();
+        $scope.lockedStaffProfileBlock = Boolean(
+          user && user.employeeId && $scope.block.profileType === 'EMAIL',
+        );
       },
     };
   });

--- a/app/scripts/directives/blocks.js
+++ b/app/scripts/directives/blocks.js
@@ -20,10 +20,14 @@ angular.module('confRegistrationWebApp').directive('nameQuestion', function () {
   return {
     templateUrl: nameQuestionTemplate,
     restrict: 'E',
-    controller: function ($scope) {
+    controller: function ($rootScope, $scope) {
       if (!$scope.answer && !$scope.answer.value) {
         $scope.answer.value = {};
       }
+
+      $scope.lockedStaffProfileBlock =
+        !!$rootScope.globalUser().employeeId &&
+        $scope.block.profileType === 'NAME';
     },
   };
 });
@@ -64,6 +68,11 @@ angular
     return {
       templateUrl: emailQuestionTemplate,
       restrict: 'E',
+      controller: function ($rootScope, $scope) {
+        $scope.lockedStaffProfileBlock =
+          !!$rootScope.globalUser().employeeId &&
+          $scope.block.profileType === 'EMAIL';
+      },
     };
   });
 

--- a/app/views/blocks/emailQuestion.html
+++ b/app/views/blocks/emailQuestion.html
@@ -7,7 +7,7 @@
   ng-model="answer.value"
   ng-model-options="{ debounce: 1000 }"
   ng-required="block.required"
-  ng-disabled="editBlock"
+  ng-disabled="editBlock || lockedStaffProfileBlock"
 />
 <span class="help-block help-block-hidden" translate
   >Please enter a valid email such as: example@example.com</span

--- a/app/views/blocks/nameQuestion.html
+++ b/app/views/blocks/nameQuestion.html
@@ -8,7 +8,7 @@
       ng-model="answer.value.firstName"
       ng-model-options="{ debounce: 300 }"
       ng-required="block.required"
-      ng-disabled="editBlock"
+      ng-disabled="editBlock || lockedStaffProfileBlock"
     />
   </div>
   <div class="col-sm-6">
@@ -20,7 +20,7 @@
       ng-model="answer.value.lastName"
       ng-model-options="{ debounce: 300 }"
       ng-required="block.required"
-      ng-disabled="editBlock"
+      ng-disabled="editBlock || lockedStaffProfileBlock"
     />
   </div>
 </div>

--- a/test/spec/directives/block.spec.js
+++ b/test/spec/directives/block.spec.js
@@ -63,6 +63,27 @@ describe('Directive: blocks', () => {
           expect($scope.lockedStaffProfileBlock).toBe(false);
         });
       });
+
+      describe('with no profile', () => {
+        beforeEach(() => {
+          spyOn($rootScope, 'globalUser').and.returnValue(null);
+        });
+
+        it('is false when the profile type is NAME', () => {
+          $compile('<name-question></name-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+
+        it('is false when the profile type is not NAME', () => {
+          $scope.block.profileType = null;
+          $compile('<name-question></name-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+      });
     });
   });
 
@@ -107,6 +128,27 @@ describe('Directive: blocks', () => {
       describe('for non-staff', () => {
         beforeEach(() => {
           spyOn($rootScope, 'globalUser').and.returnValue({ employeeId: null });
+        });
+
+        it('is false when the profile type is EMAIL', () => {
+          $compile('<email-question></email-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+
+        it('is false when the profile type is not EMAIL', () => {
+          $scope.block.profileType = null;
+          $compile('<email-question></email-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+      });
+
+      describe('with no profile', () => {
+        beforeEach(() => {
+          spyOn($rootScope, 'globalUser').and.returnValue(null);
         });
 
         it('is false when the profile type is EMAIL', () => {

--- a/test/spec/directives/block.spec.js
+++ b/test/spec/directives/block.spec.js
@@ -4,6 +4,129 @@ import _ from 'lodash';
 describe('Directive: blocks', () => {
   beforeEach(angular.mock.module('confRegistrationWebApp'));
 
+  describe('nameQuestion', () => {
+    let $compile, $rootScope, $scope;
+    beforeEach(inject((_$compile_, _$rootScope_, $templateCache, testData) => {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+
+      $scope = $rootScope.$new();
+      $scope.answer = {};
+      $templateCache.put('views/blocks/nameQuestion.html', '');
+
+      $scope.block = _.cloneDeep(
+        testData.conference.registrationPages[1].blocks[1],
+      );
+    }));
+
+    describe('lockedStaffProfileBlock', () => {
+      describe('for staff', () => {
+        beforeEach(() => {
+          spyOn($rootScope, 'globalUser').and.returnValue({
+            employeeId: '0123456',
+          });
+        });
+
+        it('is true when the profile type is NAME', () => {
+          $compile('<name-question></name-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(true);
+        });
+
+        it('is false when the profile type is not NAME', () => {
+          $scope.block.profileType = null;
+          $compile('<name-question></name-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+      });
+
+      describe('for non-staff', () => {
+        beforeEach(() => {
+          spyOn($rootScope, 'globalUser').and.returnValue({ employeeId: null });
+        });
+
+        it('is false when the profile type is NAME', () => {
+          $compile('<name-question></name-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+
+        it('is false when the profile type is not NAME', () => {
+          $scope.block.profileType = null;
+          $compile('<name-question></name-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('emailQuestion', () => {
+    let $compile, $rootScope, $scope;
+    beforeEach(inject((_$compile_, _$rootScope_, $templateCache, testData) => {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+
+      $scope = $rootScope.$new();
+      $templateCache.put('views/blocks/emailQuestion.html', '');
+
+      $scope.block = _.cloneDeep(
+        testData.conference.registrationPages[0].blocks[0],
+      );
+    }));
+
+    describe('lockedStaffProfileBlock', () => {
+      describe('for staff', () => {
+        beforeEach(() => {
+          spyOn($rootScope, 'globalUser').and.returnValue({
+            employeeId: '0123456',
+          });
+        });
+
+        it('is true when the profile type is EMAIL', () => {
+          $compile('<email-question></email-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(true);
+        });
+
+        it('is false when the profile type is not EMAIL', () => {
+          $scope.block.profileType = null;
+          $compile('<email-question></email-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+      });
+
+      describe('for non-staff', () => {
+        beforeEach(() => {
+          spyOn($rootScope, 'globalUser').and.returnValue({ employeeId: null });
+        });
+
+        it('is false when the profile type is EMAIL', () => {
+          $compile('<email-question></email-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+
+        it('is false when the profile type is not EMAIL', () => {
+          $scope.block.profileType = null;
+          $compile('<email-question></email-question>')($scope);
+          $scope.$digest();
+
+          expect($scope.lockedStaffProfileBlock).toBe(false);
+        });
+      });
+    });
+  });
+
   describe('radioQuestion', () => {
     let $compile, $rootScope, $scope, $timeout;
     beforeEach(inject((


### PR DESCRIPTION
Prevent staff from editing name and email profile fields. These fields are prepopulated and should not be modified.

If you need a conference to test with, you're welcome to use this one: https://stage.eventregistrationtool.com/eventDetails/ec6ac5f9-1df0-4b69-b09d-f85ce39001ef. It is configured to allow Okta and Google logins.

https://jira.cru.org/browse/EVENT-845