### PR TITLE
[MPDX-845] Allow editing non-primary registrant's profiles

### DIFF
--- a/app/scripts/directives/blocks.js
+++ b/app/scripts/directives/blocks.js
@@ -30,6 +30,8 @@ angular.module('confRegistrationWebApp').directive('nameQuestion', function () {
         !$scope.adminEditRegistrant &&
           user &&
           user.employeeId &&
+          $scope.currentRegistrant ===
+            $scope.currentRegistration.primaryRegistrantId &&
           $scope.block.profileType === 'NAME',
       );
     },
@@ -78,6 +80,8 @@ angular
           !$scope.adminEditRegistrant &&
             user &&
             user.employeeId &&
+            $scope.currentRegistrant ===
+              $scope.currentRegistration.primaryRegistrantId &&
             $scope.block.profileType === 'EMAIL',
         );
       },

--- a/test/spec/directives/block.spec.js
+++ b/test/spec/directives/block.spec.js
@@ -11,6 +11,7 @@ describe('Directive: blocks', () => {
       $rootScope = _$rootScope_;
 
       $scope = $rootScope.$new();
+      $scope.currentRegistration = testData.registration;
       $scope.answer = {};
       $templateCache.put('views/blocks/nameQuestion.html', '');
 
@@ -20,93 +21,57 @@ describe('Directive: blocks', () => {
     }));
 
     describe('lockedStaffProfileBlock', () => {
-      describe('for staff', () => {
-        beforeEach(() => {
-          spyOn($rootScope, 'globalUser').and.returnValue({
-            employeeId: '0123456',
-          });
+      let globalUserSpy;
+      beforeEach(() => {
+        globalUserSpy = spyOn($rootScope, 'globalUser').and.returnValue({
+          employeeId: '0123456',
         });
-
-        it('is true when the profile type is NAME', () => {
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(true);
-        });
-
-        it('is false when the profile type is not NAME', () => {
-          $scope.block.profileType = null;
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        $scope.adminEditRegistrant = null;
+        $scope.currentRegistrant =
+          $scope.currentRegistration.primaryRegistrantId;
       });
 
-      describe('for non-staff', () => {
-        beforeEach(() => {
-          spyOn($rootScope, 'globalUser').and.returnValue({ employeeId: null });
-        });
+      it('is true when staff are editing a NAME field on the primary registrant', () => {
+        $compile('<name-question></name-question>')($scope);
+        $scope.$digest();
 
-        it('is false when the profile type is NAME', () => {
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
-
-        it('is false when the profile type is not NAME', () => {
-          $scope.block.profileType = null;
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        expect($scope.lockedStaffProfileBlock).toBe(true);
       });
 
-      describe('with no profile', () => {
-        beforeEach(() => {
-          spyOn($rootScope, 'globalUser').and.returnValue(null);
-        });
+      it('is false for non-staff', () => {
+        globalUserSpy.and.returnValue({ employeeId: null });
 
-        it('is false when the profile type is NAME', () => {
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
+        $compile('<name-question></name-question>')($scope);
+        $scope.$digest();
 
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
-
-        it('is false when the profile type is not NAME', () => {
-          $scope.block.profileType = null;
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        expect($scope.lockedStaffProfileBlock).toBe(false);
       });
 
-      describe('when an admin is editing', () => {
-        beforeEach(() => {
-          $scope.adminEditRegistrant = {};
-          spyOn($rootScope, 'globalUser').and.returnValue({
-            employeeId: '0123456',
-          });
-        });
+      it('is false when an admin is editing', () => {
+        $scope.adminEditRegistrant = {};
 
-        it('is false when the profile type is NAME', () => {
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
+        $compile('<name-question></name-question>')($scope);
+        $scope.$digest();
 
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        expect($scope.lockedStaffProfileBlock).toBe(false);
+      });
 
-        it('is false when the profile type is not NAME', () => {
-          $scope.block.profileType = null;
-          $compile('<name-question></name-question>')($scope);
-          $scope.$digest();
+      it('is false when the profile type is not NAME', () => {
+        $scope.block.profileType = null;
 
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        $compile('<name-question></name-question>')($scope);
+        $scope.$digest();
+
+        expect($scope.lockedStaffProfileBlock).toBe(false);
+      });
+
+      it('is false when editing a secondary registrant', () => {
+        $scope.currentRegistrant = 'other';
+
+        $compile('<name-question></name-question>')($scope);
+        $scope.$digest();
+
+        expect($scope.lockedStaffProfileBlock).toBe(false);
       });
     });
   });
@@ -118,6 +83,7 @@ describe('Directive: blocks', () => {
       $rootScope = _$rootScope_;
 
       $scope = $rootScope.$new();
+      $scope.currentRegistration = testData.registration;
       $templateCache.put('views/blocks/emailQuestion.html', '');
 
       $scope.block = _.cloneDeep(
@@ -126,93 +92,57 @@ describe('Directive: blocks', () => {
     }));
 
     describe('lockedStaffProfileBlock', () => {
-      describe('for staff', () => {
-        beforeEach(() => {
-          spyOn($rootScope, 'globalUser').and.returnValue({
-            employeeId: '0123456',
-          });
+      let globalUserSpy;
+      beforeEach(() => {
+        globalUserSpy = spyOn($rootScope, 'globalUser').and.returnValue({
+          employeeId: '0123456',
         });
-
-        it('is true when the profile type is EMAIL', () => {
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(true);
-        });
-
-        it('is false when the profile type is not EMAIL', () => {
-          $scope.block.profileType = null;
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        $scope.adminEditRegistrant = null;
+        $scope.currentRegistrant =
+          $scope.currentRegistration.primaryRegistrantId;
       });
 
-      describe('for non-staff', () => {
-        beforeEach(() => {
-          spyOn($rootScope, 'globalUser').and.returnValue({ employeeId: null });
-        });
+      it('is true when staff are editing an EMAIL field on the primary registrant', () => {
+        $compile('<email-question></email-question>')($scope);
+        $scope.$digest();
 
-        it('is false when the profile type is EMAIL', () => {
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
-
-        it('is false when the profile type is not EMAIL', () => {
-          $scope.block.profileType = null;
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        expect($scope.lockedStaffProfileBlock).toBe(true);
       });
 
-      describe('when an admin is editing', () => {
-        beforeEach(() => {
-          $scope.adminEditRegistrant = {};
-          spyOn($rootScope, 'globalUser').and.returnValue({
-            employeeId: '0123456',
-          });
-        });
+      it('is false for non-staff', () => {
+        globalUserSpy.and.returnValue({ employeeId: null });
 
-        it('is false when the profile type is EMAIL', () => {
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
+        $compile('<email-question></email-question>')($scope);
+        $scope.$digest();
 
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
-
-        it('is false when the profile type is not EMAIL', () => {
-          $scope.block.profileType = null;
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
-
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        expect($scope.lockedStaffProfileBlock).toBe(false);
       });
 
-      describe('with no profile', () => {
-        beforeEach(() => {
-          spyOn($rootScope, 'globalUser').and.returnValue(null);
-        });
+      it('is false when an admin is editing', () => {
+        $scope.adminEditRegistrant = {};
 
-        it('is false when the profile type is EMAIL', () => {
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
+        $compile('<email-question></email-question>')($scope);
+        $scope.$digest();
 
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        expect($scope.lockedStaffProfileBlock).toBe(false);
+      });
 
-        it('is false when the profile type is not EMAIL', () => {
-          $scope.block.profileType = null;
-          $compile('<email-question></email-question>')($scope);
-          $scope.$digest();
+      it('is false when the profile type is not EMAIL', () => {
+        $scope.block.profileType = null;
 
-          expect($scope.lockedStaffProfileBlock).toBe(false);
-        });
+        $compile('<email-question></email-question>')($scope);
+        $scope.$digest();
+
+        expect($scope.lockedStaffProfileBlock).toBe(false);
+      });
+
+      it('is false when editing a secondary registrant', () => {
+        $scope.currentRegistrant = 'other';
+
+        $compile('<email-question></email-question>')($scope);
+        $scope.$digest();
+
+        expect($scope.lockedStaffProfileBlock).toBe(false);
       });
     });
   });


### PR DESCRIPTION
A HelpScout user was unable to edit their spouse's name/email because #854 disables editing all registrants' profile fields ([ticket](https://secure.helpscout.net/conversation/2592103865/1152549?viewId=7296729)). This PR relaxes that restriction to only lock the primary registrant's profile.

I also trimmed down the test cases. We don't really need an exponential number of test cases for each condition, just one test case where all the `lockedStaffProfileBlock` conditions are true and one for each of the cases where a condition is false.

If you need a conference to test with, you're welcome to use [this one](https://stage.eventregistrationtool.com/register/ec6ac5f9-1df0-4b69-b09d-f85ce39001ef). It supports registrant groups.

https://jira.cru.org/browse/EVENT-845