### PR TITLE
HelpScout1165153 Name Field issue

### DIFF
--- a/app/scripts/directives/blocks.js
+++ b/app/scripts/directives/blocks.js
@@ -30,6 +30,7 @@ angular.module('confRegistrationWebApp').directive('nameQuestion', function () {
         !$scope.adminEditRegistrant &&
           user &&
           user.employeeId &&
+          $scope.currentRegistration &&
           $scope.currentRegistrant ===
             $scope.currentRegistration.primaryRegistrantId &&
           $scope.block.profileType === 'NAME',
@@ -80,6 +81,7 @@ angular
           !$scope.adminEditRegistrant &&
             user &&
             user.employeeId &&
+            $scope.currentRegistration &&
             $scope.currentRegistrant ===
               $scope.currentRegistration.primaryRegistrantId &&
             $scope.block.profileType === 'EMAIL',

--- a/test/spec/directives/block.spec.js
+++ b/test/spec/directives/block.spec.js
@@ -47,6 +47,16 @@ describe('Directive: blocks', () => {
         expect($scope.lockedStaffProfileBlock).toBe(false);
       });
 
+      it('is false when currentRegistration is null', () => {
+        $scope.currentRegistration = null;
+        globalUserSpy.and.returnValue(null);
+
+        $compile('<name-question></name-question>')($scope);
+        $scope.$digest();
+
+        expect($scope.lockedStaffProfileBlock).toBe(false);
+      });
+
       it('is false for non-staff', () => {
         globalUserSpy.and.returnValue({ employeeId: null });
 


### PR DESCRIPTION
https://secure.helpscout.net/conversation/2613153780/1165153?folderId=7669074
### Description of issue:
1) First Name / Last Name
I noticed that within the Name fields the following:
{{'First Name' | translate}}

2) Name Tag Name Missing
For current ERT's, and ERT's I am cloning, where I once had a Name Tag Name option, I am seeing the question there, but I am noticing the response field missing.

I was not able to replicate these issues. But on this particular event, there is a typescript errors saying `Cannot read properties of undefined (reading 'primaryRegistrantId')`