### PR TITLE
[HS-1211838] Allow editing incomplete registrations

### DIFF
--- a/app/scripts/controllers/editRegistrationModal.js
+++ b/app/scripts/controllers/editRegistrationModal.js
@@ -15,6 +15,7 @@ angular
     ) {
       $scope.conference = angular.copy(conference);
       $scope.registration = angular.copy(registration);
+      $scope.adminEditing = true; // Used in emailQuestion.html to prevent converting invalid email addresses to undefined
       $scope.adminEditRegistrant = _.find($scope.registration.registrants, {
         id: registrantId,
       });

--- a/app/views/blocks/emailQuestion.html
+++ b/app/views/blocks/emailQuestion.html
@@ -5,7 +5,7 @@
   class="form-control"
   placeholder="example@example.com"
   ng-model="answer.value"
-  ng-model-options="{ debounce: 1000 }"
+  ng-model-options="{ allowInvalid: adminEditing, debounce: 1000 }"
   ng-required="block.required"
   ng-disabled="editBlock || lockedStaffProfileBlock"
 />

--- a/app/views/modals/editRegistration.html
+++ b/app/views/modals/editRegistration.html
@@ -41,12 +41,7 @@
       >
         Save &amp; Set as Completed
       </button>
-      <button
-        ng-click="submit()"
-        ng-disabled="!editRegistrationForm.$valid"
-        class="btn btn-primary"
-        translate
-      >
+      <button ng-click="submit()" class="btn btn-primary" translate>
         Save
       </button>
     </div>


### PR DESCRIPTION
We received a [HelpScout ticket](https://secure.helpscout.net/conversation/2684171191/1211838/) from an admin wanting to change the registration type on incomplete registrations. Because some required fields hadn't been filled out yet, the edit registration modal wasn't letting admins save the registration. To resolve that, this PR removes the `ng-disabled` check and lets admins always update registrations. Note that unlike `Save`, `Save & Set as Completed` still requires all questions to have valid questions.

I also had to set `allowInvalid` on `ng-model-options` for email address fields. Without it, data corruption is possible (see [screen capture](https://github.com/user-attachments/assets/5f7c0874-3ddb-4da6-b4fc-401229e16085)). To reproduce, create an incomplete registration, change the registrant type, and set the email address to an invalid value. At this point, the field is failing validation and `ng-model` sets the value to `undefined`. Saving the answer on the server without a `value` attribute will cause the email to be stored with a `null` value in the database. Then if you try to change the type, you will get an error about the email address being `null`.

To avoid this, I'm enabling `allowInvalid` on email addresses when admins are editing registrations so that invalid email addresses will still update `ng-model` and by rejected during the server-side email address validation. I'm not adding `allowInvalid` to any other fields because no other fields have server-side validation like email addresses do.

If a registration contains an invalid email address that was added before server-side email validation was added in May 2023 ([see API PR](https://github.com/CruGlobal/ert-api/pull/1023)), then admins won't be able to change the registrant type without fixing the invalid email address. I believe that that is an acceptable trade-off because legacy registrations with invalid email addresses would be over a year old by now.

Feel free to test in my Promo Test event: https://stage.eventregistrationtool.com/eventRegistrations/ec6ac5f9-1df0-4b69-b09d-f85ce39001ef