### PR TITLE
[HS-1241612] Prevent conference names from containing special characters

### DIFF
--- a/app/scripts/controllers/eventDashboard.js
+++ b/app/scripts/controllers/eventDashboard.js
@@ -41,10 +41,6 @@ angular
             templateUrl: createEventModalTemplate,
           })
           .result.then(function (conferenceName) {
-            if (!conferenceName) {
-              return;
-            }
-
             ConfCache.create(conferenceName).then(function (conference) {
               $location.path('/eventDetails/' + conference.id);
             });

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -263,6 +263,11 @@ angular
         if (_.isEmpty($scope.conference.name)) {
           validationErrors.push('Please enter an event name.');
         }
+        if (/[&"]/.test($scope.conference.name)) {
+          validationErrors.push(
+            'Please remove double quotes (") and ampersands (&) from the event name.',
+          );
+        }
 
         if (_.isEmpty($scope.conference.abbreviation)) {
           validationErrors.push('Please enter an event abbreviation.');

--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -272,6 +272,11 @@ angular
         if (_.isEmpty($scope.conference.abbreviation)) {
           validationErrors.push('Please enter an event abbreviation.');
         }
+        if (/[&"]/.test($scope.conference.abbreviation)) {
+          validationErrors.push(
+            'Please remove double quotes (") and ampersands (&) from the event abbreviation.',
+          );
+        }
 
         if (
           $scope.conference.abbreviation &&

--- a/app/views/modals/createEvent.html
+++ b/app/views/modals/createEvent.html
@@ -2,25 +2,46 @@
   <button type="button" class="close" ng-click="$dismiss()">&times;</button>
   <h3 translate>Create Event</h3>
 </div>
-<div class="modal-body">
+<div class="modal-body" ng-form="form">
   <p>
     <translate>First things, first.</translate><br />
     <translate>Let's give this event a name:</translate>
   </p>
-  <input
-    type="text"
-    class="form-control"
-    placeholder="Example: Fall Retreat 2017"
-    ng-model="name"
-    ng-enter="$close(name)"
-    auto-focus
-  />
+  <div class="form-group">
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Example: Fall Retreat 2017"
+      name="name"
+      ng-model="name"
+      ng-required="true"
+      ng-pattern='/^[^&"]+$/'
+      ng-enter="$close(name)"
+      auto-focus
+    />
+  </div>
+  <div
+    class="alert alert-danger"
+    ng-if="form.name.$invalid && form.name.$touched"
+  >
+    <p ng-if="form.name.$error.required" translate>
+      Please choose an event name.
+    </p>
+    <p ng-if="form.name.$error.pattern" translate>
+      Please choose an event name without quotes (") or ampersands (&).
+    </p>
+  </div>
 </div>
 <div class="modal-footer">
   <button ng-click="$dismiss()" class="btn btn-default" translate>
     Cancel
   </button>
-  <button ng-click="$close(name)" class="btn btn-primary" translate>
+  <button
+    ng-disabled="form.$invalid"
+    ng-click="$close(name)"
+    class="btn btn-primary"
+    translate
+  >
     Create
   </button>
 </div>

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -279,6 +279,22 @@ describe('Controller: eventDetails', function () {
         'Please enter which Event Type',
       );
     });
+
+    it('saveEvent() should validate the Event Name', () => {
+      scope.conference.name = 'Men & Women Conference';
+      scope.saveEvent();
+
+      expect(scope.notify.message.toString()).toContain(
+        'Please remove double quotes (") and ampersands (&) from the event name.',
+      );
+
+      scope.conference.name = '"Cru" Conference';
+      scope.saveEvent();
+
+      expect(scope.notify.message.toString()).toContain(
+        'Please remove double quotes (") and ampersands (&) from the event name.',
+      );
+    });
   });
 
   describe('Conference (Cru event) without ministry hosting', function () {

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -282,35 +282,40 @@ describe('Controller: eventDetails', function () {
       });
 
       it('should validate the Event Name', () => {
+        const errorMessage =
+          'Please remove double quotes (") and ampersands (&) from the event name.';
+
+        scope.saveEvent();
+
+        expect(scope.notify.message.toString()).not.toContain(errorMessage);
+
         scope.conference.name = 'Men & Women Conference';
         scope.saveEvent();
 
-        expect(scope.notify.message.toString()).toContain(
-          'Please remove double quotes (") and ampersands (&) from the event name.',
-        );
+        expect(scope.notify.message.toString()).toContain(errorMessage);
 
         scope.conference.name = '"Cru" Conference';
         scope.saveEvent();
 
-        expect(scope.notify.message.toString()).toContain(
-          'Please remove double quotes (") and ampersands (&) from the event name.',
-        );
+        expect(scope.notify.message.toString()).toContain(errorMessage);
       });
 
       it('should validate the Event Abbreviation', () => {
+        const errorMessage =
+          'Please remove double quotes (") and ampersands (&) from the event abbreviation.';
+        scope.saveEvent();
+
+        expect(scope.notify.message.toString()).not.toContain(errorMessage);
+
         scope.conference.abbreviation = 'men&women';
         scope.saveEvent();
 
-        expect(scope.notify.message.toString()).toContain(
-          'Please remove double quotes (") and ampersands (&) from the event abbreviation.',
-        );
+        expect(scope.notify.message.toString()).toContain(errorMessage);
 
         scope.conference.abbreviation = '"cru"conf';
         scope.saveEvent();
 
-        expect(scope.notify.message.toString()).toContain(
-          'Please remove double quotes (") and ampersands (&) from the event abbreviation.',
-        );
+        expect(scope.notify.message.toString()).toContain(errorMessage);
       });
     });
   });

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -268,32 +268,50 @@ describe('Controller: eventDetails', function () {
       }),
     );
 
-    it('saveEvent() should validate the Ministry Purpose', () => {
-      scope.saveEvent();
+    describe('saveEvent', () => {
+      it('should validate the Ministry Purpose', () => {
+        scope.saveEvent();
 
-      expect(scope.notify.message.toString()).toContain(
-        'Please enter Ministry Purpose.',
-      );
+        expect(scope.notify.message.toString()).toContain(
+          'Please enter Ministry Purpose.',
+        );
 
-      expect(scope.notify.message.toString()).not.toContain(
-        'Please enter which Event Type',
-      );
-    });
+        expect(scope.notify.message.toString()).not.toContain(
+          'Please enter which Event Type',
+        );
+      });
 
-    it('saveEvent() should validate the Event Name', () => {
-      scope.conference.name = 'Men & Women Conference';
-      scope.saveEvent();
+      it('should validate the Event Name', () => {
+        scope.conference.name = 'Men & Women Conference';
+        scope.saveEvent();
 
-      expect(scope.notify.message.toString()).toContain(
-        'Please remove double quotes (") and ampersands (&) from the event name.',
-      );
+        expect(scope.notify.message.toString()).toContain(
+          'Please remove double quotes (") and ampersands (&) from the event name.',
+        );
 
-      scope.conference.name = '"Cru" Conference';
-      scope.saveEvent();
+        scope.conference.name = '"Cru" Conference';
+        scope.saveEvent();
 
-      expect(scope.notify.message.toString()).toContain(
-        'Please remove double quotes (") and ampersands (&) from the event name.',
-      );
+        expect(scope.notify.message.toString()).toContain(
+          'Please remove double quotes (") and ampersands (&) from the event name.',
+        );
+      });
+
+      it('should validate the Event Abbreviation', () => {
+        scope.conference.abbreviation = 'men&women';
+        scope.saveEvent();
+
+        expect(scope.notify.message.toString()).toContain(
+          'Please remove double quotes (") and ampersands (&) from the event abbreviation.',
+        );
+
+        scope.conference.abbreviation = '"cru"conf';
+        scope.saveEvent();
+
+        expect(scope.notify.message.toString()).toContain(
+          'Please remove double quotes (") and ampersands (&) from the event abbreviation.',
+        );
+      });
     });
   });
 


### PR DESCRIPTION
# Description

* Prevent users from creating conferences with names containing ampersand or double quotes. Apparently, those special characters are causing issues on the server.
* Also prevent users from editing conferences to contain an ampersand or double quote. If they have an existing conference with an ampersand or a double quote, they will change the name before they can edit any other conference details. My understanding is that that is desirable.
* Also prevent users from editing conference abbreviations to contain an ampersand or double quote.

# Testing

* From the admin dashboard, click "Create New Event"
  * Validate that there are errors when the event name is empty (after focusing the name input and then moving focus) and the form cannot be submitted.
  * Validate that there are errors when the event name contains an ampersand (&) and the form cannot be submitted.
  * Validate that there are errors when the event name contains a double quote (") and the form cannot be submitted.
  * Validate that there are no errors when the event name is valid and the form can be submitted.
* From the admin dashboard, click on an event, then go to Details and change the Event Name.
  * Validate that there are errors when the event name contains an ampersand (&).
  * Validate that there are errors when the event name contains a double quote (").
  * Validate that there are no errors when the event name is valid and that the event name is updated.
* From the admin dashboard, click on an event, then go to Details and change the Event Abbreviation.
  * Validate that there are errors when the event abbreviation contains an ampersand (&).
  * Validate that there are errors when the event abbreviation contains a double quote (").
  * Validate that there are no errors when the event abbreviation is valid and that the event abbreviation is updated.

https://secure.helpscout.net/conversation/2731356723/1241612/

cc @hlbraddock