### PR TITLE
[HS-1310779] Liability form wording changes

### DIFF
--- a/app/scripts/controllers/eventDetails.js
+++ b/app/scripts/controllers/eventDetails.js
@@ -849,7 +849,7 @@ angular
             },
             pageId: $scope.conference.registrationPages[0].id,
             required: true,
-            title: 'Are you under 18?',
+            title: 'Are you (the participant) under 18 years old?',
             type: 'selectQuestion',
             profileType: null,
             registrantTypes: [],

--- a/app/scripts/directives/blockEditor.js
+++ b/app/scripts/directives/blockEditor.js
@@ -203,7 +203,7 @@ angular.module('confRegistrationWebApp').directive('blockEditor', function () {
       );
       const notEform = $scope.block.tag !== 'EFORM';
       $scope.canDelete = notNameOrEmail && notEform;
-      $scope.canEdit = notEform;
+      $scope.eform = !notEform;
       $scope.canCopy = notEform;
       $scope.canHaveRules = notNameOrEmail;
       $scope.canHaveAnswerRules = notNameOrEmail && $scope.hasOptions;

--- a/app/styles/event-admin.scss
+++ b/app/styles/event-admin.scss
@@ -329,8 +329,11 @@ main.event-questions {
     }
   }
 
-  .nav-tabs {
+  .edit-options {
     margin-top: 10px;
+  }
+
+  .nav-tabs {
     > li.active > a,
     > li.active > a:hover,
     > li.active > a:focus {

--- a/app/views/components/blockEditor.html
+++ b/app/views/components/blockEditor.html
@@ -28,7 +28,6 @@
       ng-if="!editBlock"
       class="btn btn-default"
       ng-click="toggleBlockEdit()"
-      ng-disabled="!canEdit"
     >
       <i class="fa fa-pencil-square-o"></i> <translate>Edit</translate>
     </button>
@@ -138,8 +137,26 @@
   </ng-switch>
 
   <div class="edit-options" ng-if="editBlock">
+    <!-- Only the title in Eform questions can be edited -->
+    <div class="form-group popup-custom-width" ng-if="eform">
+      <label class="inline-label" translate>Title</label>
+      <i
+        uib-popover-template="popup.titleTemplateUrl"
+        popover-trigger="'mouseenter'"
+        popover-placement="right"
+        class="fa fa-question-circle question-popover"
+      >
+      </i>
+      <input
+        type="text"
+        class="form-control field-label"
+        placeholder="Label"
+        ng-model="block.title"
+      />
+    </div>
+
     <!-- Tab panes -->
-    <uib-tabset>
+    <uib-tabset ng-if="!eform">
       <uib-tab heading="Options">
         <div class="form-group popup-custom-width">
           <label class="inline-label" translate>Title</label>

--- a/test/spec/controllers/eventDetails.spec.js
+++ b/test/spec/controllers/eventDetails.spec.js
@@ -191,7 +191,7 @@ describe('Controller: eventDetails', function () {
         scope.conference.registrationPages[0].blocks[
           scope.conference.registrationPages[0].blocks.length - 3
         ].title,
-      ).toEqual('Are you under 18?');
+      ).toEqual('Are you (the participant) under 18 years old?');
     });
 
     it('updateLiabilityQuestions() should delete liability related questions', () => {
@@ -214,7 +214,7 @@ describe('Controller: eventDetails', function () {
       );
 
       expect(scope.conference.registrationPages[0].blocks[1].title).toEqual(
-        'Are you under 18?',
+        'Are you (the participant) under 18 years old?',
       );
 
       expect(scope.conference.registrationPages[0].blocks[1].tag).toEqual(


### PR DESCRIPTION
## Changes

* Change the titles of auto-created liability questions to clarify that we are asking about the age of the participant (I assume this was causing confusion when parents would register for their children)
  * Note that this will not change the titles of lability questions created before this change
* Make the titles of liability questions editable

## Testing

* Create a new conference
* Check that the title of the liability question about age is "Are you (the participant) under 18 years old?"
* Check that the edit buttons for liability questions (age, guardian name, and guardian email) are not disabled
* Check that clicking the edit buttons for liability questions shows the title text input and changing it changes the question's title

Manually merged into `staging`

Requested in this ticket: https://secure.helpscout.net/conversation/2854607121/1310779/