### PR TITLE
[HS-1325929] Fix force selection checkbox being hidden

### DIFF
--- a/app/views/blocks/checkboxQuestion.html
+++ b/app/views/blocks/checkboxQuestion.html
@@ -35,25 +35,25 @@
         >
       </label>
     </div>
-  </div>
-  <div
-    class="checkbox checkbox-horizontal"
-    ng-if="answer.value[choice.value] && isAdmin"
-    ng-class="{'col-sm-4 col-xs-4':answer.value[choice.value] && isAdmin}"
-  >
-    <label
-      uib-tooltip="{{
+    <div
+      class="checkbox checkbox-horizontal"
+      ng-if="answer.value[choice.value] && isAdmin"
+      ng-class="{'col-sm-4 col-xs-4':answer.value[choice.value] && isAdmin}"
+    >
+      <label
+        uib-tooltip="{{
         'Forcing a preselected answer prevents the user from deselecting it.'
           | translate
       }}"
-    >
-      <input
-        type="checkbox"
-        ng-model="block.content.forceSelections[choice.value]"
-        ng-model-options="{ debounce: 300 }"
-        ng-value="true"
-      />
-      <strong translate>Force selection</strong>
-    </label>
+      >
+        <input
+          type="checkbox"
+          ng-model="block.content.forceSelections[choice.value]"
+          ng-model-options="{ debounce: 300 }"
+          ng-value="true"
+        />
+        <strong translate>Force selection</strong>
+      </label>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Fix DOM nesting error introduced in #876 that prevented the "Force selection" checkbox from displaying.

HelpScout ticket: https://secure.helpscout.net/conversation/2879252870/1325929?viewId=320670

## Testing

* Add a Checkbox question to the event
* Add an answer option
* Check the answer option you added
* Ensure that the Force selection checkbox is visible