### PR TITLE
[no-Jira] Fix payment amount radio button group name

### DIFF
--- a/app/views/components/payment.html
+++ b/app/views/components/payment.html
@@ -102,7 +102,7 @@
   >
     <input
       type="radio"
-      name="payment-method"
+      name="payment-amount"
       ng-model="currentPayment.amount"
       ng-value="currentRegistration.remainingBalance"
     />


### PR DESCRIPTION
I noticed that the payment amount radio button has the same group `name` as the payment method radio buttons. The payment amount radio button needs to be part of its own group so that it can be selected in addition to a payment method option.