### PR TITLE
No-Jira - Fix Netlify staging/development inconsistency

### DIFF
--- a/app/scripts/app.config.js
+++ b/app/scripts/app.config.js
@@ -38,7 +38,8 @@ angular
     envServiceProvider.config({
       domains: {
         development: ['localhost'],
-        staging: ['stage.eventregistrationtool.com', '*.netlify.com'],
+        preview: ['*.netlify.app'],
+        staging: ['stage.eventregistrationtool.com'],
         production: [
           'www.eventregistrationtool.com',
           'eventregistrationtool.com',
@@ -46,6 +47,11 @@ angular
       },
       vars: {
         development: {
+          apiUrl:
+            'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
+          tsysEnvironment: 'staging',
+        },
+        preview: {
           apiUrl:
             'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
           tsysEnvironment: 'staging',
@@ -67,7 +73,8 @@ angular
 
     if (
       envServiceProvider.is('production') ||
-      envServiceProvider.is('staging')
+      envServiceProvider.is('staging') ||
+      envServiceProvider.is('preview')
     ) {
       $compileProvider.debugInfoEnabled(false);
     }

--- a/app/scripts/app.config.js
+++ b/app/scripts/app.config.js
@@ -59,7 +59,7 @@ angular
         staging: {
           apiUrl:
             'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
-          tsysEnvironment: 'production',
+          tsysEnvironment: 'staging',
         },
         production: {
           apiUrl: 'https://api.eventregistrationtool.com/eventhub-api/rest/',


### PR DESCRIPTION
## Description

Netlify migrated deploy-preview hostnames from *.netlify.com to *.netlify.app years ago, but our envService domain list still pointed at the stale .com pattern. As a result, deploy previews fell through to the development env which happened to work only because development and staging share the same staging API URL.

### This PR:

- Adds an explicit preview environment matching *.netlify.app, using the staging API + TSYS sandbox (so payment flows tested on previews never hit live processing).
- Removes the now-stale *.netlify.com entry from staging. Any URL still on the old domain (extremely unlikely) would fall through to development.
- Extends the $compileProvider.debugInfoEnabled(false) gate to include preview, turning off Angular's debug-info classes/methods on deploy previews — small perf win on data-heavy pages.
- Changes ERT's staging and preview TSYS environments to staging instead of production.

Question: Do we want to instead just re-add Netlify correctly to the staging config?

## Testing

- Test preview environment behavior: https://deploy-preview-985--eventregistrationtool.netlify.app/

## Checklist

- [x] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
