### PR TITLE
[No-Jira] Disable account number during registration

### DIFF
--- a/app/scripts/directives/payment.js
+++ b/app/scripts/directives/payment.js
@@ -36,6 +36,7 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
       $scope.currentYear = new Date().getFullYear();
       $scope.creditCardCountry = 'US';
       $scope.countries = allCountries;
+      $scope.disable = false;
 
       $scope.paymentMethodsViews = {
         CREDIT_CARD: creditCardTemplate,
@@ -382,6 +383,8 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
               profile.staffAccountNumber ||
               transformEmployeeIdIntoAccountNumber() ||
               '';
+
+            $scope.disable = !!profile.staffAccountNumber;
           },
           function () {
             $scope.currentPayment.transfer.accountNumber = '';
@@ -397,6 +400,7 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
           fetchStaffAccountNumber();
         } else {
           $scope.currentPayment.transfer.accountNumber = '';
+          $scope.disable = false;
         }
         [
           $scope.currentPayment.transfer.businessUnit,

--- a/app/scripts/directives/payment.js
+++ b/app/scripts/directives/payment.js
@@ -36,7 +36,7 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
       $scope.currentYear = new Date().getFullYear();
       $scope.creditCardCountry = 'US';
       $scope.countries = allCountries;
-      $scope.disable = false;
+      $scope.accountNumberDisabled = false;
 
       $scope.paymentMethodsViews = {
         CREDIT_CARD: creditCardTemplate,
@@ -373,6 +373,8 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
       }
 
       function fetchStaffAccountNumber() {
+        $scope.accountNumberDisabled = false;
+
         // staffAccountNumber is fetched asynchronously after login
         // and may not be in the cached profile yet, so refetch to pick it up
         ProfileCache.clearCache();
@@ -384,10 +386,11 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
               transformEmployeeIdIntoAccountNumber() ||
               '';
 
-            $scope.disable = !!profile.staffAccountNumber;
+            $scope.accountNumberDisabled = !!profile.staffAccountNumber;
           },
           function () {
             $scope.currentPayment.transfer.accountNumber = '';
+            $scope.accountNumberDisabled = false;
           },
         );
       }
@@ -400,7 +403,7 @@ angular.module('confRegistrationWebApp').directive('ertPayment', function () {
           fetchStaffAccountNumber();
         } else {
           $scope.currentPayment.transfer.accountNumber = '';
-          $scope.disable = false;
+          $scope.accountNumberDisabled = false;
         }
         [
           $scope.currentPayment.transfer.businessUnit,

--- a/app/views/paymentMethods/transfer.html
+++ b/app/views/paymentMethods/transfer.html
@@ -84,6 +84,7 @@
         ng-model="currentPayment.transfer.accountNumber"
         type="text"
         class="form-control"
+        ng-disabled="disable"
       />
     </label>
   </div>

--- a/app/views/paymentMethods/transfer.html
+++ b/app/views/paymentMethods/transfer.html
@@ -84,7 +84,7 @@
         ng-model="currentPayment.transfer.accountNumber"
         type="text"
         class="form-control"
-        ng-disabled="disable"
+        ng-disabled="accountNumberDisabled"
       />
     </label>
   </div>

--- a/test/spec/directives/payment.spec.js
+++ b/test/spec/directives/payment.spec.js
@@ -58,6 +58,24 @@ describe('Directive: ertPayment', function () {
     scope.$apply();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('9870123457');
+    expect(scope.disable).toBe(true);
+  });
+
+  it('accountTypeChanged to STAFF should prefill employeeId when not an admin payment and staffAccountNumber is not available', () => {
+    $rootScope.globalUser.and.returnValue({
+    employeeId: '1234567',
+  });
+  ProfileCache.getCache.and.returnValue(
+    $q.resolve({ staffAccountNumber: '' }),
+  );
+    scope.currentPayment = {
+      transfer: { accountType: 'STAFF', accountNumber: '123' },
+    };
+    scope.accountTypeChanged();
+    scope.$apply();
+
+    expect(scope.currentPayment.transfer.accountNumber).toBe('1234567');
+    expect(scope.disable).toBe(false);
   });
 
   it('accountTypeChanged to STAFF should not prefill accountNumber when an admin payment', () => {
@@ -68,6 +86,7 @@ describe('Directive: ertPayment', function () {
     scope.accountTypeChanged();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('');
+    expect(scope.disable).toBe(false);
   });
 
   it('accountTypeChanged to something not equal to STAFF should not prefill accountNumber', () => {
@@ -77,6 +96,7 @@ describe('Directive: ertPayment', function () {
     scope.accountTypeChanged();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('');
+    expect(scope.disable).toBe(false);
   });
 
   it('accountTypeChanged to NON_US_STAFF should pre-fill businessUnit and department', () => {

--- a/test/spec/directives/payment.spec.js
+++ b/test/spec/directives/payment.spec.js
@@ -63,11 +63,11 @@ describe('Directive: ertPayment', function () {
 
   it('accountTypeChanged to STAFF should prefill employeeId when not an admin payment and staffAccountNumber is not available', () => {
     $rootScope.globalUser.and.returnValue({
-    employeeId: '1234567',
-  });
-  ProfileCache.getCache.and.returnValue(
-    $q.resolve({ staffAccountNumber: '' }),
-  );
+      employeeId: '1234567',
+    });
+    ProfileCache.getCache.and.returnValue(
+      $q.resolve({ staffAccountNumber: '' }),
+    );
     scope.currentPayment = {
       transfer: { accountType: 'STAFF', accountNumber: '123' },
     };

--- a/test/spec/directives/payment.spec.js
+++ b/test/spec/directives/payment.spec.js
@@ -48,6 +48,7 @@ describe('Directive: ertPayment', function () {
     scope.$apply();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('');
+    expect(scope.accountNumberDisabled).toBe(false);
   });
 
   it('accountTypeChanged to STAFF should prefill accountNumber when not an admin payment', () => {
@@ -58,12 +59,12 @@ describe('Directive: ertPayment', function () {
     scope.$apply();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('9870123457');
-    expect(scope.disable).toBe(true);
+    expect(scope.accountNumberDisabled).toBe(true);
   });
 
   it('accountTypeChanged to STAFF should prefill employeeId when not an admin payment and staffAccountNumber is not available', () => {
     $rootScope.globalUser.and.returnValue({
-      employeeId: '1234567',
+      employeeId: '0001234567',
     });
     ProfileCache.getCache.and.returnValue(
       $q.resolve({ staffAccountNumber: '' }),
@@ -75,7 +76,7 @@ describe('Directive: ertPayment', function () {
     scope.$apply();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('1234567');
-    expect(scope.disable).toBe(false);
+    expect(scope.accountNumberDisabled).toBe(false);
   });
 
   it('accountTypeChanged to STAFF should not prefill accountNumber when an admin payment', () => {
@@ -86,7 +87,7 @@ describe('Directive: ertPayment', function () {
     scope.accountTypeChanged();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('');
-    expect(scope.disable).toBe(false);
+    expect(scope.accountNumberDisabled).toBe(false);
   });
 
   it('accountTypeChanged to something not equal to STAFF should not prefill accountNumber', () => {
@@ -96,7 +97,7 @@ describe('Directive: ertPayment', function () {
     scope.accountTypeChanged();
 
     expect(scope.currentPayment.transfer.accountNumber).toBe('');
-    expect(scope.disable).toBe(false);
+    expect(scope.accountNumberDisabled).toBe(false);
   });
 
   it('accountTypeChanged to NON_US_STAFF should pre-fill businessUnit and department', () => {


### PR DESCRIPTION
## Description

During SIT2 testing, it was brought up that we want to disable the "Account Number" field on Staff transfers during registration.

Things to note:
- We want to ensure we do not disable the field when `employeeId` is being used to preserve the original logic (not 100% sure if this is needed, but I don't think it's a bad idea)
- We also don't want to disable this field when an admin is making the payment for a registrant

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Type in a search term
- Check that the event dates render
-->
Registration Test: with staff account id ✅
- Go to `/register/3b88f5e9-545f-4cb8-8640-1bb252acf0ff/page/`
- Register for "Ben's Test Event"
- During payment, select "Cru Staff / Ministry Account Transfer" and "Staff"
- Check that the account number field is disabled with correct staff account id

Admin payment test: ✅
- Go to a registrant in your own event
- Click the green button under "Paid"
- Go to "Add" tab and select a staff transfer
- Verify the account number field is enabled with nothing populated

Registration Test: without staff account id ✅
<img width="633" height="421" alt="Screenshot 2026-05-12 at 4 01 50 PM" src="https://github.com/user-attachments/assets/ab82c345-5293-4312-980a-e45f0d6dcf01" />


## Checklist

- [x] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
