### PR TITLE
[HS-1621020] Handle missing currency

### DIFF
--- a/app/features/eventDetails/regTypes.html
+++ b/app/features/eventDetails/regTypes.html
@@ -63,8 +63,7 @@
                 <div class="input-group">
                   <span class="input-group-addon" aria-hidden="true"
                     ><span class="currency-label"
-                      >{{conference.currency.currencyCode |
-                      localizedSymbol}}</span
+                      >{{conference.currency.shortSymbol}}</span
                     ></span
                   >
                   <input
@@ -416,8 +415,7 @@
                   <div class="input-group">
                     <span class="input-group-addon" aria-hidden="true">
                       <span class="currency-label"
-                        >{{conference.currency.currencyCode |
-                        localizedSymbol}}</span
+                        >{{conference.currency.shortSymbol}}</span
                       >
                     </span>
                     <input
@@ -521,8 +519,7 @@
                     <div class="input-group">
                       <span class="input-group-addon" aria-hidden="true"
                         ><span class="currency-label"
-                          >{{conference.currency.currencyCode |
-                          localizedSymbol}}</span
+                          >{{conference.currency.shortSymbol}}</span
                         ></span
                       >
                       <input

--- a/app/features/eventRegistrations/eventRegistrations.html
+++ b/app/features/eventRegistrations/eventRegistrations.html
@@ -610,8 +610,7 @@
                   title="View/Edit Payments &amp; Expenses"
                 >
                   <span class="currency-label"
-                    >{{conference.currency.currencyCode |
-                    localizedSymbol}}</span
+                    >{{conference.currency.shortSymbol}}</span
                   >
                 </button>
               </div>

--- a/app/features/paymentApproval/paymentApproval.html
+++ b/app/features/paymentApproval/paymentApproval.html
@@ -27,7 +27,7 @@
               <div class="input-group">
                 <span class="input-group-addon" aria-hidden="true"
                   ><span class="currency-label">
-                    {{conference.currency.currencyCode | localizedSymbol}}
+                    {{conference.currency.shortSymbol}}
                   </span>
                 </span>
                 <input

--- a/app/features/paymentModal/paymentsModal.html
+++ b/app/features/paymentModal/paymentsModal.html
@@ -409,8 +409,7 @@
                           <div class="input-group">
                             <span class="input-group-addon" aria-hidden="true">
                               <span class="currency-label"
-                                >{{conference.currency.currencyCode |
-                                localizedSymbol}}</span
+                                >{{conference.currency.shortSymbol}}</span
                               ></span
                             >
                             <input
@@ -788,8 +787,7 @@
                 <div class="input-group">
                   <span class="input-group-addon" aria-hidden="true"
                     ><span class="currency-label"
-                      >{{conference.currency.currencyCode |
-                      localizedSymbol}}</span
+                      >{{conference.currency.shortSymbol}}</span
                     ></span
                   >
                   <input
@@ -968,7 +966,7 @@
             <div class="input-group">
               <span class="input-group-addon" aria-hidden="true"
                 ><span class="currency-label"
-                  >{{conference.currency.currencyCode | localizedSymbol}}</span
+                  >{{conference.currency.shortSymbol}}</span
                 ></span
               >
               <input

--- a/app/scripts/components/JournalUploadPage/JournalUploadPage.tsx
+++ b/app/scripts/components/JournalUploadPage/JournalUploadPage.tsx
@@ -66,9 +66,7 @@ export const JournalUploadPage = ({
 
   const localizedCurrency = (amount: number) =>
     $filter('localizedCurrency')(amount, conference.currency.currencyCode);
-  const currencySymbol: string = $filter('localizedSymbol')(
-    conference.currency.currencyCode,
-  );
+  const currencySymbol: string = conference.currency.shortSymbol;
 
   const { open: openPaymentsModal } = usePaymentsModal({
     $http,

--- a/app/scripts/components/PromoUploadPage/PromoUploadPage.tsx
+++ b/app/scripts/components/PromoUploadPage/PromoUploadPage.tsx
@@ -71,9 +71,7 @@ export const PromoUploadPage: FunctionComponent<PromoUploadPageProps> = ({
 
   const localizedCurrency = (amount: number) =>
     $filter('localizedCurrency')(amount, conference.currency.currencyCode);
-  const currencySymbol: string = $filter('localizedSymbol')(
-    conference.currency.currencyCode,
-  );
+  const currencySymbol: string = conference.currency.shortSymbol;
 
   const { open: openPaymentsModal } = usePaymentsModal({
     $http,

--- a/app/scripts/directives/blockEditor/blockEditor.js
+++ b/app/scripts/directives/blockEditor/blockEditor.js
@@ -349,7 +349,7 @@ angular.module('confRegistrationWebApp').directive('blockEditor', function () {
                 return $scope.block.type;
               },
               currency: function () {
-                return $scope.conference.currency.currencyCode;
+                return $scope.conference.currency;
               },
             },
           })

--- a/app/scripts/directives/blockEditor/choiceOptions.html
+++ b/app/scripts/directives/blockEditor/choiceOptions.html
@@ -31,9 +31,7 @@
     <label translate>Additional Cost</label>
     <div class="input-group">
       <span class="input-group-addon" aria-hidden="true"
-        ><span class="currency-label"
-          >{{currency | localizedSymbol}}</span
-        ></span
+        ><span class="currency-label">{{currency.shortSymbol}}</span></span
       >
       <input
         type="text"
@@ -49,7 +47,7 @@
         <span translate
           >If the registrant selects this option, the total cost can be
           adjusted. Example: A book could add an additional {{5 |
-          localizedCurrency: currency}} to the cost.</span
+          localizedCurrency: currency.currencyCode}} to the cost.</span
         >
       </p>
     </div>

--- a/app/scripts/directives/payment/payment.html
+++ b/app/scripts/directives/payment/payment.html
@@ -79,7 +79,7 @@
     <div class="input-group">
       <span class="input-group-addon" aria-hidden="true"
         ><span class="currency-label"
-          >{{conference.currency.currencyCode | localizedSymbol}}</span
+          >{{conference.currency.shortSymbol}}</span
         ></span
       >
       <input

--- a/app/scripts/directives/promotion/promotion.html
+++ b/app/scripts/directives/promotion/promotion.html
@@ -46,9 +46,7 @@
           <span translate>Discount Amount</span>
           <div class="input-group">
             <span class="input-group-addon" aria-hidden="true">
-              <span class="currency-label">
-                {{currencyCode | localizedSymbol}}
-              </span>
+              <span class="currency-label"> {{currencySymbol}} </span>
             </span>
             <input
               type="number"

--- a/app/scripts/directives/promotion/promotion.ts
+++ b/app/scripts/directives/promotion/promotion.ts
@@ -18,7 +18,7 @@ interface PromotionScope extends IScope {
   onDelete?: () => void;
 
   // Local state and methods
-  currencyCode: string;
+  currencySymbol: string;
   expanded: boolean;
   activities: MinistryActivity[];
   toggleExpanded: () => void;
@@ -37,7 +37,7 @@ angular.module('confRegistrationWebApp').directive('promotion', function () {
       onDelete: '&?',
     },
     controller($scope: PromotionScope, MinistriesCache: MinistriesCache) {
-      $scope.currencyCode = $scope.conference?.currency.currencyCode ?? 'USD';
+      $scope.currencySymbol = $scope.conference?.currency.shortSymbol ?? '$';
 
       $scope.expanded = false;
       $scope.toggleExpanded = function () {

--- a/app/scripts/exceptionHandler.js
+++ b/app/scripts/exceptionHandler.js
@@ -1,0 +1,13 @@
+import { Rollbar } from 'scripts/errorNotify.js';
+
+// AngularJS catches digest/interpolation exceptions internally and routes them
+// through $exceptionHandler, so they never hit window.onerror and Rollbar's
+// captureUncaught misses them. This decorator forwards them to Rollbar.
+angular.module('confRegistrationWebApp').config(function ($provide) {
+  $provide.decorator('$exceptionHandler', function ($delegate) {
+    return function (exception, cause) {
+      Rollbar.error(exception, { cause: cause });
+      $delegate(exception, cause);
+    };
+  });
+});

--- a/app/scripts/exceptionHandler.spec.js
+++ b/app/scripts/exceptionHandler.spec.js
@@ -1,0 +1,22 @@
+import 'angular-mocks';
+import { Rollbar } from 'scripts/errorNotify.js';
+
+describe('Service: $exceptionHandler', function () {
+  beforeEach(function () {
+    angular.mock.module('confRegistrationWebApp');
+    angular.mock.module(function ($exceptionHandlerProvider) {
+      $exceptionHandlerProvider.mode('log');
+    });
+  });
+
+  it('should report exceptions to Rollbar', inject(function (
+    $exceptionHandler,
+  ) {
+    spyOn(Rollbar, 'error');
+    const exception = new Error('boom');
+
+    $exceptionHandler(exception, 'digest');
+
+    expect(Rollbar.error).toHaveBeenCalledWith(exception, { cause: 'digest' });
+  }));
+});

--- a/app/scripts/filters/localizedCurrency.js
+++ b/app/scripts/filters/localizedCurrency.js
@@ -12,19 +12,3 @@ angular
       });
     };
   });
-
-angular
-  .module('confRegistrationWebApp')
-  .filter('localizedSymbol', ($locale) => {
-    return (currencyCode) => {
-      const localeId = $locale && $locale.id ? $locale.id : 'en-us';
-      const numberFormat = new Intl.NumberFormat(localeId, {
-        style: 'currency',
-        currency: currencyCode || 'USD',
-      });
-      const currencySymbol = numberFormat
-        .formatToParts(0)
-        .find((part) => part.type === 'currency')?.value;
-      return currencySymbol;
-    };
-  });

--- a/app/scripts/filters/localizedCurrency.js
+++ b/app/scripts/filters/localizedCurrency.js
@@ -1,3 +1,5 @@
+const defaultCurrency = 'USD';
+
 angular
   .module('confRegistrationWebApp')
   .filter('localizedCurrency', function ($locale) {
@@ -6,9 +8,16 @@ angular
         return '';
       }
       const localeId = $locale.id ? $locale.id : 'en-us';
-      return number.toLocaleString(localeId, {
-        style: 'currency',
-        currency: currencyCode || 'USD',
-      });
+      try {
+        return number.toLocaleString(localeId, {
+          style: 'currency',
+          currency: currencyCode || defaultCurrency,
+        });
+      } catch {
+        return number.toLocaleString(localeId, {
+          style: 'currency',
+          currency: defaultCurrency,
+        });
+      }
     };
   });

--- a/app/scripts/filters/localizedCurrency.js
+++ b/app/scripts/filters/localizedCurrency.js
@@ -5,7 +5,7 @@ angular
       if (number === null || number === undefined) {
         return '';
       }
-      let localeId = $locale.id ? $locale.id : 'en-us';
+      const localeId = $locale.id ? $locale.id : 'en-us';
       return number.toLocaleString(localeId, {
         style: 'currency',
         currency: currencyCode || 'USD',
@@ -15,45 +15,16 @@ angular
 
 angular
   .module('confRegistrationWebApp')
-  .filter('localizedSymbol', ($locale, $window) => {
+  .filter('localizedSymbol', ($locale) => {
     return (currencyCode) => {
-      let localeId = $locale && $locale.id ? $locale.id : 'en-us';
-      let symbol = symbolFromFormatToParts(
-        localeId,
-        currencyCode || 'USD',
-        $window,
-      );
-      if (symbol) {
-        return symbol;
-      }
-      let number = 0;
-      return number
-        .toLocaleString(localeId, {
-          style: 'currency',
-          currency: currencyCode || 'USD',
-        })
-        .replace(/[0., ]/g, '');
+      const localeId = $locale && $locale.id ? $locale.id : 'en-us';
+      const numberFormat = new Intl.NumberFormat(localeId, {
+        style: 'currency',
+        currency: currencyCode || 'USD',
+      });
+      const currencySymbol = numberFormat
+        .formatToParts(0)
+        .find((part) => part.type === 'currency')?.value;
+      return currencySymbol;
     };
   });
-
-function symbolFromFormatToParts(localeId, currencyCode, window) {
-  if (!('Intl' in window)) {
-    return;
-  }
-  let numberFormat = new Intl.NumberFormat(localeId, {
-    style: 'currency',
-    currency: currencyCode,
-  });
-  if (!('formatToParts' in numberFormat)) {
-    return;
-  }
-  // Some browsers incorrectly return nan or Nan for the formatToParts function
-  // This will filter out all incorrect results.
-  const filteredSymbol = numberFormat
-    .formatToParts()
-    .filter((e) => e.type !== 'nan' || e.value !== 'NaN');
-
-  if (filteredSymbol.length > 0) {
-    return filteredSymbol.filter((e) => e.type === 'currency')[0].value;
-  }
-}

--- a/app/scripts/filters/localizedCurrency.js
+++ b/app/scripts/filters/localizedCurrency.js
@@ -2,10 +2,13 @@ angular
   .module('confRegistrationWebApp')
   .filter('localizedCurrency', function ($locale) {
     return function (number, currencyCode) {
+      if (number === null || number === undefined) {
+        return '';
+      }
       let localeId = $locale.id ? $locale.id : 'en-us';
       return number.toLocaleString(localeId, {
         style: 'currency',
-        currency: currencyCode,
+        currency: currencyCode || 'USD',
       });
     };
   });
@@ -15,7 +18,11 @@ angular
   .filter('localizedSymbol', ($locale, $window) => {
     return (currencyCode) => {
       let localeId = $locale && $locale.id ? $locale.id : 'en-us';
-      let symbol = symbolFromFormatToParts(localeId, currencyCode, $window);
+      let symbol = symbolFromFormatToParts(
+        localeId,
+        currencyCode || 'USD',
+        $window,
+      );
       if (symbol) {
         return symbol;
       }
@@ -23,7 +30,7 @@ angular
       return number
         .toLocaleString(localeId, {
           style: 'currency',
-          currency: currencyCode,
+          currency: currencyCode || 'USD',
         })
         .replace(/[0., ]/g, '');
     };

--- a/app/scripts/filters/localizedCurrency.spec.js
+++ b/app/scripts/filters/localizedCurrency.spec.js
@@ -16,6 +16,20 @@ describe('Filter: localizedCurrency', function () {
 
     expect(filter(amount, 'USD')).toContain('123.12');
   });
+
+  it('should format zero amounts', function () {
+    expect(filter(0, 'USD')).toContain('0.00');
+  });
+
+  it('should fall back to USD when currency code is missing', function () {
+    expect(filter(123.12, undefined)).toContain('123.12');
+    expect(filter(123.12, null)).toContain('123.12');
+  });
+
+  it('should return an empty string when amount is missing', function () {
+    expect(filter(undefined, 'USD')).toBe('');
+    expect(filter(null, 'USD')).toBe('');
+  });
 });
 
 describe('Filter: localizedSymbol', function () {
@@ -31,5 +45,10 @@ describe('Filter: localizedSymbol', function () {
 
   it('should format currency symbol', function () {
     expect(filter('USD')).toBe('$');
+  });
+
+  it('should fall back to USD when currency code is missing', function () {
+    expect(filter(undefined)).toBe('$');
+    expect(filter(null)).toBe('$');
   });
 });

--- a/app/scripts/filters/localizedCurrency.spec.js
+++ b/app/scripts/filters/localizedCurrency.spec.js
@@ -31,24 +31,3 @@ describe('Filter: localizedCurrency', function () {
     expect(filter(null, 'USD')).toBe('');
   });
 });
-
-describe('Filter: localizedSymbol', function () {
-  let filter;
-
-  beforeEach(function () {
-    angular.mock.module('confRegistrationWebApp');
-
-    inject(function ($injector) {
-      filter = $injector.get('$filter')('localizedSymbol');
-    });
-  });
-
-  it('should format currency symbol', function () {
-    expect(filter('USD')).toBe('$');
-  });
-
-  it('should fall back to USD when currency code is missing', function () {
-    expect(filter(undefined)).toBe('$');
-    expect(filter(null)).toBe('$');
-  });
-});

--- a/app/scripts/filters/localizedCurrency.spec.js
+++ b/app/scripts/filters/localizedCurrency.spec.js
@@ -26,6 +26,10 @@ describe('Filter: localizedCurrency', function () {
     expect(filter(123.12, null)).toContain('123.12');
   });
 
+  it('should fall back to USD when currency code is invalid', function () {
+    expect(filter(123.12, 'BOGUS')).toContain('123.12');
+  });
+
   it('should return an empty string when amount is missing', function () {
     expect(filter(undefined, 'USD')).toBe('');
     expect(filter(null, 'USD')).toBe('');

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,5 +1,6 @@
 import 'scripts/clientSideRedirection.js';
 import 'scripts/app.module.js';
+import 'scripts/exceptionHandler.js';
 import 'scripts/app.config.js';
 import 'scripts/app.run.js';
 import 'scripts/app_enforceAuth.js';


### PR DESCRIPTION
## Description

Some conferences don't have a currency set. This can cause `localizedCurrency` throw an exception, preventing the page from rendering.

After I made this PR, I saw the user's response that they have a currency set. So this may not fix their bug. But it will at least fix it for other conferences and make it easier to debug future issues like this.

I also cleaned up the `localizedSymbol` implementation. We don't need feature checks for `Intl.NumberFormat.formatToParts` anymore.

HelpScout ticket: https://secure.helpscout.net/conversation/3326003234/1621020/

## Testing

Not directly testable. But I tested locally rendering `| localizedCurrency` in a conference without a currency. The tests also exercise this.

## Checklist

- [x] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [ ] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
