### PR TITLE
[HS-1621020] Stop throwing when a question references a rule that was deleted

### DIFF
--- a/app/scripts/services/validateRegistrant.js
+++ b/app/scripts/services/validateRegistrant.js
@@ -82,10 +82,12 @@ angular
                 ? parseFloat(rule.value)
                 : rule.value;
             }
-            // Hide this block if the question that the rule is based on (parentBlock) is hidden.
+            // Hide this block if the question that the rule is based on (parentBlock) is hidden or deleted.
+            // The parentBlock may have been deleted, leaving an orphaned rule.
             let parentBlock = _.find(blocks, { id: rule.parentBlockId });
             if (
               conference &&
+              parentBlock &&
               !blockVisibleRuleCheck(
                 parentBlock,
                 registrant,

--- a/app/scripts/services/validateRegistrant.js
+++ b/app/scripts/services/validateRegistrant.js
@@ -82,12 +82,11 @@ angular
                 ? parseFloat(rule.value)
                 : rule.value;
             }
-            // Hide this block if the question that the rule is based on (parentBlock) is hidden or deleted.
-            // The parentBlock may have been deleted, leaving an orphaned rule.
+            // Hide this block if the question that the rule is based on (parentBlock) is hidden.
             let parentBlock = _.find(blocks, { id: rule.parentBlockId });
             if (
               conference &&
-              parentBlock &&
+              parentBlock && // the server strips out admin-only blocks, so the parent might be missing
               !blockVisibleRuleCheck(
                 parentBlock,
                 registrant,

--- a/app/scripts/services/validateRegistrant.spec.js
+++ b/app/scripts/services/validateRegistrant.spec.js
@@ -484,6 +484,45 @@ describe('Service: validateRegistrant', function () {
     });
   });
 
+  describe('orphaned rules (parent block deleted)', function () {
+    let conference, registrant, Q2Multiple;
+
+    beforeEach(() => {
+      conference = angular.copy(testData.conference);
+      // Delete Q1, the parent block that Q2's SHOW_QUESTION rule references
+      const page = conference.registrationPages[2];
+      page.blocks = page.blocks.filter(
+        (block) => block.id !== 'd6f1b12a-8c98-4e83-8857-1111111',
+      );
+      Q2Multiple = _.find(page.blocks, {
+        id: '38f8ece0-adf7-423d-9588-2222222',
+      });
+
+      registrant = angular.copy(testData.registration.registrants[0]);
+      // Registrant still has a stale answer for the deleted block
+      _.find(registrant.answers, {
+        blockId: 'd6f1b12a-8c98-4e83-8857-1111111',
+      }).value = 'radio option - show child';
+    });
+
+    it('blockVisible evaluates the rule against the stale answer without throwing', function () {
+      expect(
+        validateRegistrant.blockVisible(
+          Q2Multiple,
+          registrant,
+          false,
+          conference,
+        ),
+      ).toBe(true);
+    });
+
+    it('validate does not throw', function () {
+      expect(() =>
+        validateRegistrant.validate(conference, registrant),
+      ).not.toThrow();
+    });
+  });
+
   describe('shouldShowForRegistrantType()', function () {
     const registrant = { id: 'reg1', registrantTypeId: 'type1' };
 


### PR DESCRIPTION
## Description

A particular conference is having issues when people review their completed registrations to pay for it. This issue is likely a crash when `parentBlock` is undefined.

HelpScout ticket: https://secure.helpscout.net/conversation/3326003234/1621020/
Rollbar occurrence: https://app.rollbar.com/a/Cru/fix/item/ert-web/1017/occurrence/462407511837#detail

## Testing

- *I'm still working on recreating the issue locally and verifying the fix*

## Checklist

- [x] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [ ] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
