### PR TITLE
Change preview api url with hcm url

### DIFF
--- a/app/scripts/app.config.js
+++ b/app/scripts/app.config.js
@@ -54,7 +54,7 @@ angular
         },
         preview: {
           apiUrl:
-            'https://api.stage.eventregistrationtool.com/eventhub-api/rest/',
+            'https://ert-hcm-stage.cru.org/eventhub-api/rest/',
           tsysEnvironment: 'staging',
         },
         staging: {


### PR DESCRIPTION
## Description

**DO NOT DEPLOY THIS**

Creating another preview environment since Rob Eberly is having issues with accessing the dashboard page. Testing if this will work for him instead.

Preview environment: https://deploy-preview-992--eventregistrationtool.netlify.app/

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Type in a search term
- Check that the event dates render
-->

- Go to ...
- Do ...
- Check that ...

## Checklist

- [ ] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [ ] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
