### PR TITLE
[No-Jira] Fix null profile types for CAMPUS_V2

### DIFF
--- a/app/features/eventForm/eventForm.controller.js
+++ b/app/features/eventForm/eventForm.controller.js
@@ -45,7 +45,7 @@ angular
       var formSaving = false;
       var formSavingTimeout;
       var formSavingNotifyTimeout;
-      
+
       function normalizeCampusProfileTypes() {
         (
           ($scope.conference && $scope.conference.registrationPages) ||

--- a/app/features/eventForm/eventForm.controller.js
+++ b/app/features/eventForm/eventForm.controller.js
@@ -45,6 +45,22 @@ angular
       var formSaving = false;
       var formSavingTimeout;
       var formSavingNotifyTimeout;
+      
+      function normalizeCampusProfileTypes() {
+        (
+          ($scope.conference && $scope.conference.registrationPages) ||
+          []
+        ).forEach(function (page) {
+          (page.blocks || []).forEach(function (block) {
+            if (
+              block.type === 'campusV2Question' &&
+              block.profileType !== 'CAMPUS_V2'
+            ) {
+              block.profileType = 'CAMPUS_V2';
+            }
+          });
+        });
+      }
 
       function saveForm() {
         $timeout.cancel(formSavingTimeout);
@@ -56,6 +72,7 @@ angular
         }
 
         formSaving = true;
+        normalizeCampusProfileTypes();
         let conferenceWithoutImage = angular.copy($scope.conference);
         conferenceWithoutImage.image = null;
 

--- a/app/features/eventForm/eventForm.controller.spec.js
+++ b/app/features/eventForm/eventForm.controller.spec.js
@@ -138,9 +138,11 @@ describe('Controller: eventForm', function () {
       const page = scope.conference.registrationPages[0];
 
       scope.$apply(() => {
-        page.blocks.push(
-          { id: 'campus-v2-block', type: 'campusV2Question', profileType: null },
-        );
+        page.blocks.push({
+          id: 'campus-v2-block',
+          type: 'campusV2Question',
+          profileType: null,
+        });
       });
       $httpBackend.flush();
 

--- a/app/features/eventForm/eventForm.controller.spec.js
+++ b/app/features/eventForm/eventForm.controller.spec.js
@@ -127,6 +127,29 @@ describe('Controller: eventForm', function () {
     });
   });
 
+  describe('normalizeCampusProfileTypes', () => {
+    beforeEach(() => {
+      scope.$digest();
+    });
+
+    it('forces campusV2Question blocks to the CAMPUS_V2 profile type on save', () => {
+      spyOn(ConfCache, 'update');
+      $httpBackend.expectPUT(/^conferences\/.+$/).respond(204, '');
+      const page = scope.conference.registrationPages[0];
+
+      scope.$apply(() => {
+        page.blocks.push(
+          { id: 'campus-v2-block', type: 'campusV2Question', profileType: null },
+        );
+      });
+      $httpBackend.flush();
+
+      expect(
+        page.blocks.find((block) => block.id === 'campus-v2-block').profileType,
+      ).toBe('CAMPUS_V2');
+    });
+  });
+
   describe('previewForm', () => {
     it('navigates to the preview page', () => {
       spyOn($location, 'path');

--- a/app/features/eventForm/eventForm.controller.spec.js
+++ b/app/features/eventForm/eventForm.controller.spec.js
@@ -132,23 +132,30 @@ describe('Controller: eventForm', function () {
       scope.$digest();
     });
 
-    it('forces campusV2Question blocks to the CAMPUS_V2 profile type on save', () => {
+    it('forces campusV2Question blocks to CAMPUS_V2 on save, leaving other blocks untouched', () => {
       spyOn(ConfCache, 'update');
       $httpBackend.expectPUT(/^conferences\/.+$/).respond(204, '');
       const page = scope.conference.registrationPages[0];
 
       scope.$apply(() => {
-        page.blocks.push({
-          id: 'campus-v2-block',
-          type: 'campusV2Question',
-          profileType: null,
-        });
+        page.blocks.push(
+          {
+            id: 'campus-v2-block',
+            type: 'campusV2Question',
+            profileType: null,
+          },
+          { id: 'name-block', type: 'nameQuestion', profileType: 'NAME' },
+        );
       });
       $httpBackend.flush();
 
       expect(
         page.blocks.find((block) => block.id === 'campus-v2-block').profileType,
       ).toBe('CAMPUS_V2');
+
+      expect(
+        page.blocks.find((block) => block.id === 'name-block').profileType,
+      ).toBe('NAME');
     });
   });
 


### PR DESCRIPTION
## Description

HelpScout ticket [#1665844](https://secure.helpscout.net/conversation/3373373152/1665844?viewId=8728581) raised issues with the connections school id displaying instead of the school name. I found that the profile type was `null` when it should have been `CAMPUS_V2` which was causing the bug.

Upon further investigation, I found out there are 3 ways a campus v2 question can have a `null` profile type:
1. Unchecking "Cru Profile" when editing the campus question
2. Copying the campus v2 question and then deleting the original
3. Dragging a duplicate campus v2 question and then deleting the original

To prevent this from happening, we need to restore the profile type on save to ensure no campus question persists without it.

**Note:** This will only fix events after an update is made, so I asked Ben if he can see how many events were affected and if he can change the profile type to `CAMPUS_V2`

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Type in a search term
- Check that the event dates render
-->

- Go to event dashboard and create an event with a campus question
- Go to registration page and ensure university appears (you must already have a connections id set)
- Go back to event and try # 1 above
- Navigate back to registration page and verify university is still there
- Repeat with # 2 and # 3

## Checklist

- [x] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
