### PR TITLE
ci: bump GitHub Actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     name: ✅ Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -24,7 +24,7 @@ jobs:
       - name: 🧪 Run Tests
         run: yarn test
       - name: Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/karma/lcov.info,./coverage/jest/lcov.info
@@ -33,8 +33,8 @@ jobs:
     name: 🧹 ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -45,8 +45,8 @@ jobs:
     name: 🔍 TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -57,8 +57,8 @@ jobs:
     name: 🎨 Prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -70,8 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, eslint, typescript, prettier]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -86,8 +86,8 @@ jobs:
     needs: [build]
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies


### PR DESCRIPTION
## Summary

Updates the CI workflow to use the newer GitHub Actions versions that run on the current Node 24 runtime, replacing the deprecated old-Node versions. This matches the standard used in our other repos (e.g. `mpdx-react`).

- `actions/checkout@v4` → `@v7`
- `actions/setup-node@v4` → `@v7`
- `codecov/codecov-action@v2` → `@v5`

## Notes

- `node-version-file: .tool-versions` (nodejs 24.3.0) still works with `setup-node@v7` — no change needed.
- `codecov-action@v5` reads the token via the same `token` input, so no config change was required.
- Left `aws-actions/configure-aws-credentials` pinned to its commit SHA, as pinning is the more secure practice and it's unrelated to the Node-runtime bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)