### PR TITLE
HS-1701446 - Disable double payment in the event that payment is processed but the registration completion fails

### DIFF
--- a/app/features/reviewRegistration/reviewRegistration.controller.js
+++ b/app/features/reviewRegistration/reviewRegistration.controller.js
@@ -218,15 +218,16 @@ angular
       };
 
       // Display an error that occurred during registration completion
-      function handleRegistrationError(error) {
-        if (!error) {
+      function handleRegistrationError(error, paymentCharged) {
+        if (!paymentCharged && !error) {
           return;
         }
 
         modalMessage.error({
-          message:
-            error.message ||
-            'An error occurred while attempting to complete your registration.',
+          message: paymentCharged
+            ? 'Your card was charged successfully, but there was a problem completing your registration. Please contact the event administrator.'
+            : error.message ||
+              'An error occurred while attempting to complete your registration.',
           forceAction: true,
         });
       }
@@ -246,6 +247,11 @@ angular
           : $route.reload();
       };
 
+      // Payment processing happens before registration completion.
+      // In the event that the payment succeeds but the registration fails to complete,
+      // we must ensure that the user cannot be charged again.
+      let paymentCharged = false;
+
       // Called when the user clicks the confirm button
       $scope.confirmRegistration = function () {
         $scope.submittingRegistration = true;
@@ -260,17 +266,30 @@ angular
             );
           })
           .then(function () {
+            // If the card was already charged on a previous attempt, skip
+            // payment entirely so a retry only re-runs the remaining steps.
+            if (paymentCharged) {
+              return;
+            }
+
             // If the payment type is a gift card, the API needs to know the full registration cost.
             if ($scope.currentPayment.paymentType === 'FL_GIFT_CARD') {
               $scope.currentPayment.amount =
                 currentRegistration.calculatedTotalDue;
             }
-            return payment.pay(
-              $scope.currentPayment,
-              conference,
-              currentRegistration,
-              $scope.acceptedPaymentMethods(),
-            );
+            return payment
+              .pay(
+                $scope.currentPayment,
+                conference,
+                currentRegistration,
+                $scope.acceptedPaymentMethods(),
+              )
+              .then(function (result) {
+                if (result) {
+                  paymentCharged = true;
+                }
+                return result;
+              });
           })
           .then(function () {
             return registration.completeRegistration(currentRegistration);
@@ -284,7 +303,10 @@ angular
             $scope.navigateToPostRegistrationPage();
           })
           .catch(function (response) {
-            handleRegistrationError((response && response.data) || response);
+            handleRegistrationError(
+              (response && response.data) || response,
+              paymentCharged,
+            );
 
             $scope.submittingRegistration = false;
           });

--- a/app/features/reviewRegistration/reviewRegistration.controller.spec.js
+++ b/app/features/reviewRegistration/reviewRegistration.controller.spec.js
@@ -477,6 +477,87 @@ describe('Controller: ReviewRegistrationCtrl', function () {
     });
   });
 
+  describe('confirmRegistration payment safeguard', () => {
+    let $q;
+    let modalMessage;
+    let payment;
+    let registration;
+    let payDeferred;
+    let completeDeferred;
+
+    beforeEach(
+      angular.mock.inject(function (
+        _$q_,
+        _modalMessage_,
+        _payment_,
+        _registration_,
+      ) {
+        $q = _$q_;
+        modalMessage = _modalMessage_;
+        payment = _payment_;
+        registration = _registration_;
+
+        payDeferred = $q.defer();
+        completeDeferred = $q.defer();
+
+        spyOn(modalMessage, 'error');
+        spyOn(registration, 'validatePayment').and.returnValue($q.when());
+        spyOn(payment, 'pay').and.returnValue(payDeferred.promise);
+        spyOn(registration, 'completeRegistration').and.returnValue(
+          completeDeferred.promise,
+        );
+      }),
+    );
+
+    it('charges the card only once when completion fails and the user retries', () => {
+      // First attempt
+      scope.confirmRegistration();
+      scope.$digest();
+      payDeferred.resolve({ data: {} }); // card charged successfully
+      scope.$digest(); // completeRegistration is called
+      completeDeferred.reject({ data: {} }); // completion fails
+      scope.$digest();
+
+      expect(payment.pay).toHaveBeenCalledTimes(1);
+      expect(registration.completeRegistration).toHaveBeenCalledTimes(1);
+
+      // Second attempt
+      scope.confirmRegistration();
+      scope.$digest();
+
+      expect(registration.completeRegistration).toHaveBeenCalledTimes(2);
+      expect(payment.pay).toHaveBeenCalledTimes(1);
+    });
+
+    it('tells the user their card was charged when completion fails after payment', () => {
+      scope.confirmRegistration();
+      scope.$digest();
+      payDeferred.resolve({ data: {} });
+      scope.$digest();
+      completeDeferred.reject({ data: {} });
+      scope.$digest();
+
+      expect(modalMessage.error).toHaveBeenCalledWith({
+        message:
+          'Your card was charged successfully, but there was a problem completing your registration. Please contact the event administrator.',
+        forceAction: true,
+      });
+    });
+
+    it('shows the generic error when the payment itself fails', () => {
+      scope.confirmRegistration();
+      scope.$digest();
+      payDeferred.reject({ data: { message: 'card declined' } });
+      scope.$digest();
+
+      expect(registration.completeRegistration).not.toHaveBeenCalled();
+      expect(modalMessage.error).toHaveBeenCalledWith({
+        message: 'card declined',
+        forceAction: true,
+      });
+    });
+  });
+
   describe('pageIsVisible', () => {
     it('returns true if any blocks are visible', () => {
       initController({


### PR DESCRIPTION
## Description

### HS ticket: 
- https://secure.helpscout.net/conversation/3406039462/1701446

### Issue
- Any error during registration completion, but after payment, leads to the user being able to resubmit, and consequently, the user is re-charged for the registration.

### Implementation
- Blocks successive payments if the user has already been charged for the registration.
- Provides an explicit modal message to the user that the payment has failed and asking them to reach out to the event administrator. Successive attempts to register are allowed. This puts the onus on admin clients, which is not ideal, but is better than charging registering users multiple times.

- *This frontend change is mitigation until a fix is found for the underlying error(s) causing this issue*, and the backend is able to handle payment and registration completion atomically or can use idempotency keys

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Type in a search term
- Check that the event dates render
-->

- Without reproducing the bug, I am unsure that this path can be reliably user tested. The jest tests are hopefully sufficient in proving the behavior.

## Checklist

- [x] I have given my PR a title with the format "EVENT-(Jira#) - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [ ] I have requested an AI code review either locally or from Copilot and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
